### PR TITLE
Currency conversion

### DIFF
--- a/README.md
+++ b/README.md
@@ -71,7 +71,7 @@ An 'InstanceMapping' object can be created for adding a customer friendly name (
 
 Base compute units are calculated as 10 * the GBP cost. For costs received in USD (i.e. from AWS), the default exchange rate of $1 = £0.77 is used. This can be overriden using an environment variable, replacing 0.77 with the desired, more up to date value:
 
- `USD_CONVERSION=new_value ruby -e 'p ENV["USD_CONVERSION"]'`
+ `USD_GBP_CONVERSION=new_value ruby -e 'p ENV["USD_GBP_CONVERSION"]'`
 
 # Operation
 

--- a/models/aws_project.rb
+++ b/models/aws_project.rb
@@ -110,16 +110,16 @@ class AwsProject < Project
       start_date = start_date > date.beginning_of_month ? start_date : date.beginning_of_month
       compute_costs_this_month = @explorer.get_cost_and_usage(compute_cost_query(start_date, date + 1, "MONTHLY")).results_by_time[0]
       compute_costs = compute_costs_this_month.total["UnblendedCost"][:amount].to_f
-      compute_costs = (compute_costs * 10 * 1.25).ceil
+      compute_costs = (compute_costs * CostLog::USD_GBP_CONVERSION * 10 * 1.25).ceil
 
       data_egress_this_month = @explorer.get_cost_and_usage(data_out_query(start_date, date + 1, "MONTHLY")).results_by_time[0]
       data_egress_amount = data_egress_this_month.total["UsageQuantity"][:amount].to_f.ceil(2)
       data_egress_costs = data_egress_this_month.total["UnblendedCost"][:amount].to_f
-      data_egress_costs = (data_egress_costs * 10 * 1.25).ceil
+      data_egress_costs = (data_egress_costs * CostLog::USD_GBP_CONVERSION * 10 * 1.25).ceil
 
       costs_this_month = @explorer.get_cost_and_usage(all_costs_query(start_date, date + 1, "MONTHLY")).results_by_time[0]
       total_costs = costs_this_month.total["UnblendedCost"][:amount].to_f
-      total_costs = (total_costs * 10 * 1.25).ceil
+      total_costs = (total_costs * CostLog::USD_GBP_CONVERSION * 10 * 1.25).ceil
 
       logs = self.instance_logs.where('timestamp LIKE ?', "%#{date == Date.today - 2 ? Date.today : date}%").where(compute: 1)
       future_costs = 0.0
@@ -128,7 +128,7 @@ class AwsProject < Project
           future_costs += @@prices[self.region][log.instance_type]
         end
       end
-      daily_future_cu = (future_costs * 24 * 10 * 1.25).ceil
+      daily_future_cu = (future_costs * CostLog::USD_GBP_CONVERSION * 24 * 10 * 1.25).ceil
       total_future_cu = (daily_future_cu + fixed_daily_cu_cost).ceil
 
       remaining_budget = self.budget.to_i - total_costs

--- a/models/cost_log.rb
+++ b/models/cost_log.rb
@@ -3,14 +3,11 @@ require 'active_record'
 ActiveRecord::Base.establish_connection(adapter: 'sqlite3', database: 'db/cost_tracker.sqlite3')
 
 class CostLog < ActiveRecord::Base
+  USD_GBP_CONVERSION = ENV['USD_GBP_CONVERSION'] ? ENV['USD_GBP_CONVERSION'].to_f : 0.77
   belongs_to :project
 
-  def usd_to_gbp
-    ENV["USD_CONVERSION"] ? ENV["USD_CONVERSION"].to_f : 0.77
-  end
-
   def compute_cost
-    gbp_cost = self.currency == "USD" ? (self.cost.to_f * usd_to_gbp) : self.cost.to_f
+    gbp_cost = self.currency == "USD" ? (self.cost.to_f * USD_GBP_CONVERSION) : self.cost.to_f
     (gbp_cost * 10).ceil
   end
 


### PR DESCRIPTION
Adds currency conversion for costs received in USD. A default conversion of $1 = £0.77 is used, with the option to override this by setting the an environment variable `ENV["USD_GBP_CONVERSION"]`

Also adds some examples of argument combinations when running the report files.