### PR TITLE
Slack only option

### DIFF
--- a/README.md
+++ b/README.md
@@ -81,18 +81,21 @@ Daily reports can be generated using `ruby daily_reports.rb`. If run without any
 
 Weekly reports can similarly be generated using `ruby weekly_reports.rb`. If run without any arguments, this will iterate over all Projects in the database and retrieve data for the month so far, including estimating costs for the rest of the month. The results will be printed to the terminal and posted to the chosen slack channel(s). Weekly reports use the specified date (2 days ago by default) for historical cost data, and will use either use the specified date's instance information, or today's if generating the 'latest' report.
 
-Both of these files also take up to 4 arguments:
+Both of these files also take up to 6 arguments:
 
 1: project name or 'all'\
 2: a specific date or 'latest'. All dates must be in the format YYYY-MM-DD\
-3 (optional & unordered): 'slack' or 'text'. If text no message will be sent to slack\
-4 (optional & unordered): 'rerun' will ignore cached reports and regenerate them with fresh sdk/ api calls\
-5 (optional & unordered): 'verbose' will expand any brief Azure errors to include the full HTTP response from the Azure API instead of just the error code.
+
+The following are optional and unordered (but must be at least the third argument)\
+3: 'slack' will post the results to the chosen slack channel(s)\
+4: 'text' will print out the results\
+5: 'rerun' will ignore cached reports and regenerate them with fresh sdk/ api calls\
+6: 'verbose' will expand any brief Azure errors to include the full HTTP response from the Azure API instead of just the error code.
 
 
 ## Examples
 
-To get all projects' reports with cost data from two days ago, with slack messaging, using cached data if present:
+To get all projects' reports with cost data from two days ago, with both slack and text output, using cached data if present:
 
 `ruby daily_reports.rb` or `ruby daily_reports.rb all latest`
 
@@ -104,7 +107,13 @@ To get a report for a specific project, with cost data from two days ago, with o
 
 `ruby weekly_reports.rb projectName latest text`
 
-To get a report for a specific project for a specific date, with slack output and using cached data if present
+To get a report for a specific project, with cost data from two days ago, with only slack output and using cached data if present:
+
+`ruby daily_reports.rb projectName latest slack`
+
+`ruby weekly_reports.rb projectName latest slack`
+
+To get a report for a specific project for a specific date, with both slack and text output and using cached data if present
 
 `ruby daily_reports.rb projectName 2020-09-20`
 

--- a/README.md
+++ b/README.md
@@ -89,7 +89,7 @@ Both of these files also take up to 6 arguments:
 The following are optional and unordered (but must be at least the third argument):
 
 3: 'slack' will post the results to the chosen slack channel(s)\
-4: 'text' will print out the results\
+4: 'text' will print out the results. If no output method is specified (neither 'text' or 'slack'), results will be posted to slack and printed on the terminal\
 5: 'rerun' will ignore cached reports and regenerate them with fresh sdk/ api calls\
 6: 'verbose' will expand any brief Azure errors to include the full HTTP response from the Azure API instead of just the error code.
 

--- a/README.md
+++ b/README.md
@@ -84,9 +84,10 @@ Weekly reports can similarly be generated using `ruby weekly_reports.rb`. If run
 Both of these files also take up to 6 arguments:
 
 1: project name or 'all'\
-2: a specific date or 'latest'. All dates must be in the format YYYY-MM-DD\
+2: a specific date or 'latest'. All dates must be in the format YYYY-MM-DD
 
-The following are optional and unordered (but must be at least the third argument)\
+The following are optional and unordered (but must be at least the third argument):
+
 3: 'slack' will post the results to the chosen slack channel(s)\
 4: 'text' will print out the results\
 5: 'rerun' will ignore cached reports and regenerate them with fresh sdk/ api calls\
@@ -115,9 +116,9 @@ To get a report for a specific project, with cost data from two days ago, with o
 
 To get a report for a specific project for a specific date, with both slack and text output and using cached data if present
 
-`ruby daily_reports.rb projectName 2020-09-20`
+`ruby daily_reports.rb projectName 2020-09-20 slack text`
 
-`ruby weekly_reports.rb projectName 2020-09-20`
+`ruby weekly_reports.rb projectName 2020-09-20 slack text`
 
 To get all projects' reports for a specific day, with only text output and fresh cost and usage queries
 

--- a/daily_reports.rb
+++ b/daily_reports.rb
@@ -3,10 +3,10 @@ require 'date'
 require 'sqlite3'
 require_relative './models/project_factory'
 
-def all_projects(date, slack, rerun, verbose)
+def all_projects(date, slack, text, rerun, verbose)
   ProjectFactory.new().all_projects_as_type.each do |project|
     begin
-      project.daily_report(date, slack, rerun, verbose)
+      project.daily_report(date, slack, text, rerun, verbose)
     rescue AzureApiError => e
       puts e
     end
@@ -16,7 +16,12 @@ end
 date = Date.today - 2
 project = nil
 rerun = ARGV.include?("rerun")
-slack = !ARGV.include?("text")
+slack = ARGV.include?("slack")
+text = ARGV.include?("text")
+if !(slack || text)
+  slack = true
+  text = true
+end
 verbose = false
 if ARGV.include?("verbose")
   ARGV.delete("verbose")
@@ -40,12 +45,10 @@ if ARGV[0] && ARGV[0] != "all"
   end
   project = ProjectFactory.new().as_type(project)
   begin
-    project.daily_report(date, slack, rerun, verbose)
+    project.daily_report(date, slack, text, rerun, verbose)
   rescue AzureApiError => e
     puts e
   end
 else
-  all_projects(date, slack, rerun, verbose)
+  all_projects(date, slack, text, rerun, verbose)
 end
-
-

--- a/models/aws_project.rb
+++ b/models/aws_project.rb
@@ -43,7 +43,7 @@ class AwsProject < Project
     @pricing_checker = Aws::Pricing::Client.new(access_key_id: self.access_key_ident, secret_access_key: self.key)
   end
 
-  def daily_report(date=(Date.today - 2), slack=true, rerun=false, verbose=false)
+  def daily_report(date=(Date.today - 2), slack=true, text=true, rerun=false, verbose=false)
     @verbose = false
     start_date = Date.parse(self.start_date)
     if date < start_date
@@ -87,12 +87,14 @@ class AwsProject < Project
 
     send_slack_message(msg) if slack
 
-    puts "\nProject: #{self.name}"
-    puts msg.gsub(":moneybag:", "").gsub("*", "").gsub("\t", "")
-    puts "_" * 50
+    if text
+      puts "\nProject: #{self.name}"
+      puts msg.gsub(":moneybag:", "").gsub("*", "").gsub("\t", "")
+      puts "_" * 50
+    end
   end
 
-  def weekly_report(date=Date.today - 2, slack=true, rerun=false, verbose=false)
+  def weekly_report(date=Date.today - 2, slack=true, text=true, rerun=false, verbose=false)
     @verbose = false
     report = self.weekly_report_logs.find_by(date: date)
     msg = ""
@@ -181,8 +183,10 @@ class AwsProject < Project
       msg = "\t\t\t\t\t*Cached Report*\n" << report.content
     end
     send_slack_message(msg) if slack
-    puts (msg.gsub(":calendar:", "").gsub("*", "").gsub(":awooga:", ""))
-    puts '_' * 50
+    if text
+      puts (msg.gsub(":calendar:", "").gsub("*", "").gsub(":awooga:", ""))
+      puts '_' * 50
+    end
   end
 
   def get_latest_prices

--- a/models/azure_project.rb
+++ b/models/azure_project.rb
@@ -47,7 +47,7 @@ class AzureProject < Project
     @metadata['resource_group']
   end
 
-  def daily_report(date=Date.today-2, slack=true, rerun=false, verbose=false)
+  def daily_report(date=Date.today-2, slack=true, text=true, rerun=false, verbose=false)
     @verbose = verbose
     record_instance_logs(rerun) if date >= Date.today - 2 && date <= Date.today
     total_cost_log = self.cost_logs.find_by(date: date.to_s, scope: "total")
@@ -106,13 +106,15 @@ class AzureProject < Project
         "*Compute Instance Usage:* #{overall_usage}"
       ].join("\n") + "\n"
     send_slack_message(msg) if slack
-
-    puts "\nProject: #{self.name}\n"
-    puts msg.gsub(":moneybag:", "").gsub("*", "")
-    puts "_" * 50
+    
+    if text
+      puts "\nProject: #{self.name}\n"
+      puts msg.gsub(":moneybag:", "").gsub("*", "")
+      puts "_" * 50
+    end
   end
 
-  def weekly_report(date=Date.today - 2, slack=true, rerun=false, verbose=false)
+  def weekly_report(date=Date.today - 2, slack=true, text=true, rerun=false, verbose=false)
     @verbose = verbose
     report = self.weekly_report_logs.find_by(date: date)
     msg = ""
@@ -218,8 +220,10 @@ class AzureProject < Project
       msg = "\t\t\t\t\t*Cached Report*\n" << report.content
     end
     send_slack_message(msg) if slack
-    puts (msg.gsub(":calendar:", "").gsub("*", "").gsub(":awooga:", ""))
-    puts '_' * 50
+    if text
+      puts (msg.gsub(":calendar:", "").gsub("*", "").gsub(":awooga:", ""))
+      puts '_' * 50
+    end
   end
 
   def record_instance_logs(rerun=false)

--- a/models/project.rb
+++ b/models/project.rb
@@ -46,7 +46,7 @@ class Project < ActiveRecord::Base
     Date.parse(self.end_date) > Date.today
   end
 
-  def daily_report(date=Date.today - 2, slack=true, rerun=false)
+  def daily_report(date=Date.today - 2, slack=true, text=true, rerun=false)
   end
 
   def get_forecasts
@@ -58,7 +58,7 @@ class Project < ActiveRecord::Base
   def record_cost_log
   end
 
-  def weekly_report(date=Date.today - 2, slack=true, rerun=false)
+  def weekly_report(date=Date.today - 2, slack=true, text=true, rerun=false)
   end
 
   def get_data_out(date=Date.today - 2)

--- a/weekly_reports.rb
+++ b/weekly_reports.rb
@@ -3,10 +3,10 @@ require 'date'
 require 'sqlite3'
 require_relative './models/project_factory'
 
-def all_projects(date, slack, rerun, verbose)
+def all_projects(date, slack, text, rerun, verbose)
   ProjectFactory.new().all_projects_as_type.each do |project|
     begin
-      project.weekly_report(date, slack, rerun, verbose)
+      project.weekly_report(date, slack, text, rerun, verbose)
     rescue AzureApiError => e
       puts e
     end
@@ -16,7 +16,12 @@ end
 date = Date.today - 2
 project = nil
 rerun = ARGV.include?("rerun")
-slack = !ARGV.include?("text")
+slack = ARGV.include?("slack")
+text = ARGV.include?("text")
+if !(slack || text)
+  slack = true
+  text = true
+end
 verbose = false
 if ARGV.include?("verbose")
   ARGV.delete("verbose")
@@ -40,10 +45,10 @@ if ARGV[0] && ARGV[0] != "all"
   end
   begin
     project = ProjectFactory.new().as_type(project)
-    project.weekly_report(date, slack, rerun, verbose)
+    project.weekly_report(date, slack, text, rerun, verbose)
   rescue AzureApiError => e
     puts e
   end
 else
-  all_projects(date, slack, rerun, verbose)
+  all_projects(date, slack, text, rerun, verbose)
 end


### PR DESCRIPTION
Aims to resolve #29

- The optional argument 'slack' specifies that the output should be sent to slack
- 'text' may also be included (regardless of the inclusion of 'slack') as an argument, which will print output to the terminal
- If no output method is specified (neither 'slack' nor 'text' are passed) then results will both be posted to slack and printed in the terminal
- Readme updated