### PR TITLE
update default date and make a constant

### DIFF
--- a/daily_reports.rb
+++ b/daily_reports.rb
@@ -13,7 +13,7 @@ def all_projects(date, slack, text, rerun, verbose)
   end
 end
 
-date = Date.today - 2
+date = Project::DEFAULT_DATE
 project = nil
 rerun = ARGV.include?("rerun")
 slack = ARGV.include?("slack")

--- a/models/aws_project.rb
+++ b/models/aws_project.rb
@@ -54,7 +54,7 @@ class AwsProject < Project
       return
     end
 
-    record_instance_logs(rerun) if date >= DEFAULT_DATE && date <= Date.today
+    record_instance_logs(rerun) if date == DEFAULT_DATE
     
     cached = !rerun && self.cost_logs.find_by(date: date.to_s, scope: "total")
 

--- a/models/azure_project.rb
+++ b/models/azure_project.rb
@@ -47,9 +47,9 @@ class AzureProject < Project
     @metadata['resource_group']
   end
 
-  def daily_report(date=Date.today-3, slack=true, text=true, rerun=false, verbose=false)
+  def daily_report(date=DEFAULT_DATE, slack=true, text=true, rerun=false, verbose=false)
     @verbose = verbose
-    record_instance_logs(rerun) if date >= DEFAULT_DATE && date <= Date.today
+    record_instance_logs(rerun) if date == DEFAULT_DATE
     total_cost_log = self.cost_logs.find_by(date: date.to_s, scope: "total")
     data_out_cost_log = self.cost_logs.find_by(date: date.to_s, scope: "data_out")
     data_out_amount_log = self.usage_logs.find_by(start_date: date.to_s, description: "data_out")

--- a/models/project.rb
+++ b/models/project.rb
@@ -9,6 +9,7 @@ ActiveRecord::Base.establish_connection(adapter: 'sqlite3', database: 'db/cost_t
 
 class Project < ActiveRecord::Base
   FIXED_MONTHLY_CU_COST = 5000
+  DEFAULT_DATE = Date.today - 3
   belongs_to :customer
   has_many :cost_logs
   has_many :instance_logs

--- a/weekly_reports.rb
+++ b/weekly_reports.rb
@@ -13,7 +13,7 @@ def all_projects(date, slack, text, rerun, verbose)
   end
 end
 
-date = Date.today - 2
+date = Project::DEFAULT_DATE
 project = nil
 rerun = ARGV.include?("rerun")
 slack = ARGV.include?("slack")


### PR DESCRIPTION
Aims to resolve #40

- Changes default date to be 3 days in the past rather than 2, to give more time for azure costs to stabilise
- For consistency, applies to both azure and aws projects
- For daily and weekly reports
- This is now defined by a constant `DEFAULT_DATE` within the `Project` class, to facilitate simpler updates in the future if needed
- Further validation required that this a sufficient time gap to ensure azure accuracy