### PR TITLE
Handle AWS SDK errors and provide option to validate project credentials

### DIFF
--- a/daily_reports.rb
+++ b/daily_reports.rb
@@ -34,8 +34,10 @@ def all_projects(date, slack, text, rerun, verbose, customer_facing)
   ProjectFactory.new().all_active_projects_as_type.each do |project|
     begin
       project.daily_report(date, slack, text, rerun, verbose, customer_facing)
-    rescue AzureApiError => e
+    rescue AzureApiError, AwsSdkError => e
+      puts "Generation of daily report for project #{project.name} stopped due to error: "
       puts e
+      puts "_" * 50
     end
   end
 end
@@ -75,7 +77,8 @@ if ARGV[0] && ARGV[0] != "all"
   project = ProjectFactory.new().as_type(project)
   begin
     project.daily_report(date, slack, text, rerun, verbose, customer_facing)
-  rescue AzureApiError => e
+  rescue AzureApiError, AwsSdkError => e
+    puts "Generation of weekly report for project #{project.name} stopped due to error: "
     puts e
   end
 else

--- a/manage_projects.rb
+++ b/manage_projects.rb
@@ -29,7 +29,7 @@ require_relative './models/project_factory'
 require 'table_print'
 
 def add_or_update_project(action=nil)
-  factory = ProjectFactory.new
+  @factory = ProjectFactory.new
   if action == nil
     print "List, add or update project(s) (list/add/update)? "
     action = gets.chomp.downcase
@@ -398,6 +398,7 @@ def add_project
     valid = project.valid?
   end
   project.save
+  p = @factory.as_type(project)
   puts "Project #{project.name} created"
 end
 

--- a/manage_projects.rb
+++ b/manage_projects.rb
@@ -40,11 +40,12 @@ def add_or_update_project(action=nil)
     project = Project.find_by_name(project_name)
     if project == nil
       puts "Project not found. Please try again."
-      return add_or_update_project("update")
+      return add_or_update_project(action)
     end
     project = @factory.as_type(project)
     if action == "validate"
-      return validate_credentials(project)
+      validate_credentials(project)
+      return add_or_update_project
     end
     puts project.name
     puts "host: #{project.host}"
@@ -460,7 +461,6 @@ def validate_credentials(project)
   project = @factory.as_type(project)
   project.validate_credentials
   puts
-  add_or_update_project
 end
 
 # for table print

--- a/manage_projects.rb
+++ b/manage_projects.rb
@@ -88,15 +88,11 @@ def update_attributes(project)
     update_regions(project)
   elsif attribute == "resource_groups" || attribute == "resource groups"
     update_resource_groups(project)
-  elsif attribute == "location"
-    print "Value: "
-    value = gets.chomp
-    project.location = value
   else
     if attribute == "metadata"
       metadata = JSON.parse(project.metadata)
       keys = metadata.keys
-      keys = keys - ["regions", "resource_groups", "location", "bearer_token", "bearer_expiry"]
+      keys = keys - ["regions", "resource_groups", "bearer_token", "bearer_expiry"]
       puts "Possible keys: #{keys.join(", ")}"
       print "Key name: "
       key = gets.chomp
@@ -300,8 +296,13 @@ def add_project
   attributes = {}
   print "Project name: "
   attributes[:name] = gets.chomp
-  print "Host (aws or azure): "
-  attributes[:host] = gets.chomp.downcase
+  valid = false
+  while !valid
+    print "Host (aws or azure): "
+    value = gets.chomp.downcase
+    valid = ["aws", "azure"].include?(value)
+    valid ? attributes[:host] = value : (puts "Invalid selection. Please enter aws or azure.")
+  end
   valid_date = false
   while !valid_date
     print "Start date (YYYY-MM-DD): "
@@ -332,6 +333,9 @@ def add_project
       puts "Invalid date. Please ensure it is in the format YYYY-MM-DD"
     end
   end
+  
+  print "Start date (YYYY-MM-DD): "
+  attributes[:start_date] = gets.chomp
   print "Budget (c.u./month): "
   attributes[:budget] = gets.chomp
   print "Slack Channel: "
@@ -454,10 +458,9 @@ end
 
 def validate_credentials(project)
   project = @factory.as_type(project)
-  valid = project.validate_credentials
-  if !valid
-    "Please check your credentials and permissions. Entered values can be corrected by rerunning this file and selecting 'update'."
-  end
+  project.validate_credentials
+  puts
+  add_or_update_project
 end
 
 # for table print

--- a/models/aws_project.rb
+++ b/models/aws_project.rb
@@ -85,6 +85,36 @@ class AwsProject < Project
     end
   end
 
+  def validate_creds
+    valid = true
+    begin
+      @explorer.get_cost_and_usage(time_period: {start: Date.today.to_s, end: Date.today.to_s})
+    rescue => error
+      valid = false
+      puts "Unable to connect to AWS Cost Explorer: #{error}"
+    end
+    
+    begin
+      @instances_checker.describe_instances
+    rescue => error
+      valide = false
+      puts "Unable to connect to AWS EC2: #{error}."
+    end
+
+    begin
+      @pricing_checker.get_products(format_version: "aws_v1", max_results: 1)
+    rescue => error
+      valid = false
+      puts "Unable to connect to AWS Pricing: #{error}"
+    end
+
+    if valid
+      puts "Credentials valid for project #{self.name}."
+    else
+      puts "Please double check your credentials and permissions."
+    end
+  end
+
   def daily_report(date=(DEFAULT_DATE), slack=true, text=true, rerun=false, verbose=false, customer_facing=false)
     @verbose = false
     start_date = Date.parse(self.start_date)

--- a/models/azure_project.rb
+++ b/models/azure_project.rb
@@ -34,7 +34,6 @@ class AzureProject < Project
 
   after_initialize :construct_metadata
   after_initialize :update_region_mappings
-  after_initialize :refresh_auth_token
 
   def tenant_id
     @metadata['tenant_id']
@@ -76,8 +75,53 @@ class AzureProject < Project
     resource_groups.join(", ")
   end
 
+  def validate_credentials
+    puts "Validating Azure project credentials. This may take some time (2-3 mins).\n\n"
+    valid = true
+    @verbose = true
+    begin
+      update_bearer_token
+    rescue => error
+      valid = false
+      puts "#{error}\n\n"
+    end
+
+    begin
+      api_query_active_nodes
+    rescue => error
+      valid = false
+      puts "#{error}\n\n"
+    end
+    
+    begin
+      api_query_cost(Date.today.to_s)
+    rescue => error
+      valid = false
+      puts "#{error}\n\n"
+    end
+
+    uri = "https://management.azure.com/subscriptions/#{subscription_id}/providers/Microsoft.Commerce/RateCard?api-version=2016-08-31-preview&$filter=OfferDurableId eq 'MS-AZR-0003P' and Currency eq 'GBP' and Locale eq 'en-GB' and RegionInfo eq 'GB'"
+    response = HTTParty.get(
+      uri,
+      headers: { 'Authorization': "Bearer #{bearer_token}" }
+      )
+
+    if !response.success?
+      valid = false
+      puts "Unable to connect to AWS Pricing: #{response}\n\n"
+    end
+
+    if valid
+      puts "Credentials valid for project #{self.name}."
+    else
+      puts "Please double check your credentials and permissions."
+    end
+    valid
+  end
+
   def daily_report(date=DEFAULT_DATE, slack=true, text=true, rerun=false, verbose=false, customer_facing=false)
     @verbose = verbose
+    update_bearer_token
     record_instance_logs(rerun) if date == DEFAULT_DATE
     total_cost_log = self.cost_logs.find_by(date: date.to_s, scope: "total")
     data_out_cost_log = self.cost_logs.find_by(date: date.to_s, scope: "data_out")
@@ -145,6 +189,7 @@ class AzureProject < Project
 
   def weekly_report(date=DEFAULT_DATE, slack=true, text=true, rerun=false, verbose=false, customer_facing=true)
     @verbose = verbose
+    update_bearer_token
     report = self.weekly_report_logs.find_by(date: date)
     msg = ""
     if report == nil || rerun
@@ -406,9 +451,7 @@ class AzureProject < Project
       vms = response['value']
       vms.select { |vm| vm.key?('tags') && vm['tags']['type'] == 'compute' && self.resource_groups.include?(vm['id'].split('/')[4].downcase) }
     else
-      raise AzureApiError.new("Error querying compute nodes for project #{name}.\n
-                              Error code #{response.code}.\n
-                              #{response if @verbose}")
+      raise AzureApiError.new("Error querying compute nodes for project #{name}.\nError code #{response.code}.\n#{response if @verbose}")
     end
   end
 
@@ -434,9 +477,7 @@ class AzureProject < Project
     if response.success?
       details = response['value']
     else
-      raise AzureApiError.new("Error querying daily cost Azure API for project #{name}.\n
-                          Error code #{response.code}.\n
-                          #{response if @verbose}")
+      raise AzureApiError.new("Error querying daily cost Azure API for project #{name}.\nError code #{response.code}.\n#{response if @verbose}")
     end
   end
 
@@ -462,9 +503,7 @@ class AzureProject < Project
         end
       end
     else
-      raise AzureApiError.new("Error querying node status Azure API for project #{name}.\n
-                              Error code #{response.code}.\n
-                              #{response if @verbose}")
+      raise AzureApiError.new("Error querying node status Azure API for project #{name}.\nError code #{response.code}.\n#{response if @verbose}")
     end
   end
 
@@ -489,9 +528,7 @@ class AzureProject < Project
       self.metadata = @metadata.to_json
       self.save
     else
-      raise AzureApiError.new("Error obtaining new authorization token for project #{name}.\n
-                              Error code #{response.code}/\n
-                              #{response if @verbose}")
+      raise AzureApiError.new("Error obtaining new authorization token for project #{name}.\nError code #{response.code}\n#{response if @verbose}")
     end
   end
 
@@ -524,8 +561,7 @@ class AzureProject < Project
           end
         end
       else
-        raise AzureApiError.new("Error obtaining latest Azure price list. Error code #{response.code}.\n
-                                #{response if @verbose}")
+        raise AzureApiError.new("Error obtaining latest Azure price list. Error code #{response.code}.\n#{response if @verbose}")
       end
     end
   end

--- a/models/azure_project.rb
+++ b/models/azure_project.rb
@@ -108,7 +108,7 @@ class AzureProject < Project
 
     if !response.success?
       valid = false
-      puts "Unable to connect to AWS Pricing: #{response}\n\n"
+      puts "Unable to connect to Azure Pricing: #{response}\n\n"
     end
 
     if valid

--- a/models/project.rb
+++ b/models/project.rb
@@ -58,7 +58,7 @@ class Project < ActiveRecord::Base
     }
   scope :active, -> { 
     where("end_date > ? OR end_date IS NULL", Date.today).where(
-          "start_date <= ?", Date.today)
+          "start_date <= ?", Date.today).reorder(:host)
   }
   
   def aws?

--- a/models/project.rb
+++ b/models/project.rb
@@ -56,7 +56,6 @@ class Project < ActiveRecord::Base
       in: %w(aws azure),
       message: "%{value} is not a valid host"
     }
-  default_scope { order(:host) }
   scope :active, -> { 
     where("end_date > ? OR end_date IS NULL", Date.today).where(
           "start_date <= ?", Date.today)

--- a/models/project.rb
+++ b/models/project.rb
@@ -56,9 +56,10 @@ class Project < ActiveRecord::Base
       in: %w(aws azure),
       message: "%{value} is not a valid host"
     }
+  default_scope { order(:host) }
   scope :active, -> { 
     where("end_date > ? OR end_date IS NULL", Date.today).where(
-          "start_date <= ?", Date.today).reorder(:host)
+          "start_date <= ?", Date.today)
   }
   
   def aws?

--- a/weekly_reports.rb
+++ b/weekly_reports.rb
@@ -34,8 +34,10 @@ def all_projects(date, slack, text, rerun, verbose, customer_facing)
   ProjectFactory.new().all_active_projects_as_type.each do |project|
     begin
       project.weekly_report(date, slack, text, rerun, verbose, customer_facing)
-    rescue AzureApiError => e
+    rescue AzureApiError, AwsSdkError => e
+      puts "Generation of weekly report for project #{project.name} stopped due to error: "
       puts e
+      puts "_" * 50
     end
   end
 end
@@ -74,7 +76,8 @@ if ARGV[0] && ARGV[0] != "all"
   begin
     project = ProjectFactory.new().as_type(project)
     project.weekly_report(date, slack, text, rerun, verbose, customer_facing)
-  rescue AzureApiError => e
+  rescue AzureApiError, AwsSdkError => e
+    puts "Generation of weekly report for project #{project.name} stopped due to error: "
     puts e
   end
 else


### PR DESCRIPTION
Aims to resolve #22 and #23, adding validation and protection from errors raised due to invalid credentials

**AWS SDK Error handling**
- Now rescues errors raised by the various AWS SDKs used, using them to create custom `AwsSdkError`s
- When running `weekly_reports.rb` and `daily_reports.rb` now rescues both `AzureApiError`s and these new `AwsSdkError`s (only), printing the output
- This prevents the application breaking if an AWS project has invalid credentials (which in turn can prevent subsequent project reports being generated
- As with Azure projects, the optional argument `verbose` provides further detail
- Also some minor updates to formatting of azure error print outs
- For `AzureProject`s, `update_bearer_token` is no longer called after initialisation, as otherwise various methods break if trying to initialise an `AzureProject` with invalid credentials

![Screenshot from 2020-10-20 11-03-12](https://user-images.githubusercontent.com/59840834/96572937-5f338000-12c5-11eb-85fa-538426791856.png)


**Validating project credentials**
 - Adds a new option 'validate' to `manage_projects.rb`
- This will attempt some API/ SDK queries for the project. If any errors, the results are printed
- Users are asked if they want to run this validation after creating or updating a project, to help with checking projects before trying to generate their reports

![Screenshot from 2020-10-19 16-44-41](https://user-images.githubusercontent.com/59840834/96572973-6bb7d880-12c5-11eb-8064-86ab4abc7465.png)


Also includes some general fixes:
- Removes various unused AWS queries
- Adds more validations to `manage_projects.rb`

