### PR TITLE
only generate reports for active projects

### DIFF
--- a/daily_reports.rb
+++ b/daily_reports.rb
@@ -31,7 +31,7 @@ require 'sqlite3'
 require_relative './models/project_factory'
 
 def all_projects(date, slack, text, rerun, verbose, customer_facing)
-  ProjectFactory.new().all_projects_as_type.each do |project|
+  ProjectFactory.new().all_active_projects_as_type.each do |project|
     begin
       project.daily_report(date, slack, text, rerun, verbose, customer_facing)
     rescue AzureApiError => e

--- a/models/project.rb
+++ b/models/project.rb
@@ -70,8 +70,8 @@ class Project < ActiveRecord::Base
   end
 
   def active?
-    return true if !self.end_date
-    Date.parse(self.end_date) > Date.today
+    Date.parse(self.start_date) <= Date.today &&
+    (!self.end_date || Date.parse(self.end_date) > Date.today)
   end
 
   def daily_report(date=DEFAULT_DATE, slack=true, text=true, rerun=false, verbose=false, customer_facing=false)

--- a/weekly_reports.rb
+++ b/weekly_reports.rb
@@ -31,7 +31,7 @@ require 'sqlite3'
 require_relative './models/project_factory'
 
 def all_projects(date, slack, text, rerun, verbose, customer_facing)
-  ProjectFactory.new().all_projects_as_type.each do |project|
+  ProjectFactory.new().all_active_projects_as_type.each do |project|
     begin
       project.weekly_report(date, slack, text, rerun, verbose, customer_facing)
     rescue AzureApiError => e


### PR DESCRIPTION
Fixes lost code:

- When generating reports for all projects, only generate reports for active projects
- Updates that project is 'active' if start date is today or in the past, and either no end date or end date is in the future
- Does not apply if running a report for a specific, named project