### PR TITLE
Only ask for start date once during project creation

### DIFF
--- a/manage_projects.rb
+++ b/manage_projects.rb
@@ -335,8 +335,6 @@ def add_project
     end
   end
   
-  print "Start date (YYYY-MM-DD): "
-  attributes[:start_date] = gets.chomp
   print "Budget (c.u./month): "
   attributes[:budget] = gets.chomp
   print "Slack Channel: "


### PR DESCRIPTION
Aims to resolve #60

- When creating a new project using `manage_projects.rb` now only asks for start date once