### PR TITLE
Record budget history

### DIFF
--- a/db/generate_budgets.rb
+++ b/db/generate_budgets.rb
@@ -30,75 +30,41 @@ load './models/project.rb'
 
 db = SQLite3::Database.open 'db/cost_tracker.sqlite3'
 
-db.execute "CREATE TABLE IF NOT EXISTS customers(
-  name TEXT,
-  id INTEGER PRIMARY KEY AUTOINCREMENT
-)"
-
-db.execute "CREATE TABLE IF NOT EXISTS projects(
-  name TEXT,
-  id INTEGER PRIMARY KEY AUTOINCREMENT,
-  client_id INTEGER,
-  host TEXT,
-  start_date TEXT,
-  end_date TEXT,
-  slack_channel TEXT,
-  metadata TEXT
-)"
-
-db.execute "CREATE TABLE IF NOT EXISTS instance_logs(
-  id INTEGER PRIMARY KEY AUTOINCREMENT,
-  project_id INTEGER,
-  host TEXT,
-  instance_name TEXT,
-  instance_id TEXT,
-  instance_type TEXT,
-  region TEXT,
-  compute INTEGER,
-  status TEXT,
-  timestamp TEXT
-)"
-
-db.execute "CREATE TABLE IF NOT EXISTS cost_logs(
-  id INTEGER PRIMARY KEY AUTOINCREMENT,
-  project_id INTEGER,
-  cost REAL,
-  currency TEXT,
-  date TEXT,
-  scope TEXT,
-  timestamp TEXT
-)"
-
-db.execute "CREATE TABLE IF NOT EXISTS usage_logs(
-  id INTEGER PRIMARY KEY AUTOINCREMENT,
-  project_id INTEGER,
-  scope TEXT,
-  description TEXT,
-  unit TEXT,
-  amount REAL,
-  start_date TEXT,
-  end_date TEXT,
-  timestamp TEXT
-)"
-
-db.execute "CREATE TABLE IF NOT EXISTS weekly_report_logs(
-  id INTEGER PRIMARY KEY AUTOINCREMENT,
-  project_id INTEGER,
-  content TEXT,
-  date TEXT,
-  timestamp TEXT
-)"
-
-db.execute "CREATE TABLE IF NOT EXISTS instance_mappings(
-  id INTEGER PRIMARY KEY AUTOINCREMENT,
-  instance_type TEXT,
-  customer_facing_name TEXT
-)"
-
 db.execute "CREATE TABLE IF NOT EXISTS budgets(
   id INTEGER PRIMARY KEY AUTOINCREMENT,
   project_id INTEGER,
   amount INTEGER,
   effective_at TEXT,
   timestamp TEXT
-)"
+  )"
+
+Project.all.each do |project|
+  if project.budgets.length == 0
+    Budget.create(
+    {
+      project_id: project.id,
+      amount: project.budget,
+      effective_at: project.start_date,
+      timestamp: Time.now
+    })
+  end
+end
+
+if Project.first.budget != nil
+  db.execute "ALTER TABLE projects RENAME TO projects_old;"
+  db.execute "CREATE TABLE projects( 
+      name TEXT,
+      id INTEGER PRIMARY KEY AUTOINCREMENT,
+      client_id INTEGER,
+      host TEXT,
+      start_date TEXT,
+      end_date TEXT,
+      slack_channel TEXT,
+      metadata TEXT
+    );"
+  db.execute "INSERT INTO projects (name, id, client_id, host, start_date, end_date, slack_channel, metadata)
+    SELECT name, id, client_id, host, start_date, end_date, slack_channel, metadata
+    FROM projects_old;
+    DROP TABLE projects_old;
+    COMMIT;"
+end

--- a/db/generate_budgets.rb
+++ b/db/generate_budgets.rb
@@ -38,19 +38,18 @@ db.execute "CREATE TABLE IF NOT EXISTS budgets(
   timestamp TEXT
   )"
 
-Project.all.each do |project|
-  if project.budgets.length == 0
-    Budget.create(
-    {
-      project_id: project.id,
-      amount: project.budget,
-      effective_at: project.start_date,
-      timestamp: Time.now
-    })
+if Project.new().respond_to?(:budget)
+  Project.all.each do |project|
+    if project.budgets.length == 0
+      Budget.create({
+        project_id: project.id,
+        amount: project.budget,
+        effective_at: project.start_date,
+        timestamp: Time.now
+      })
+    end
   end
-end
 
-if Project.first.budget != nil
   db.execute "ALTER TABLE projects RENAME TO projects_old;"
   db.execute "CREATE TABLE projects( 
       name TEXT,

--- a/manage_projects.rb
+++ b/manage_projects.rb
@@ -471,7 +471,7 @@ def add_budget(project)
     print "Budget amount (c.u./month): "
     amount = gets.chomp
     valid = begin
-      !!Integer(amount, 10)
+      Integer(amount, 10)
     rescue ArgumentError, TypeError
       false
     end

--- a/manage_projects.rb
+++ b/manage_projects.rb
@@ -51,7 +51,7 @@ def add_or_update_project(action=nil)
     puts "host: #{project.host}"
     puts "start_date: #{project.start_date}"
     puts "end_date: #{project.end_date}"
-    puts "budget: #{project.budget}c.u./month"
+    puts "budget: #{project.current_budget}c.u./month"
     puts "regions: #{project.regions.join(", ")}" if project.aws?
     puts "resource_groups: #{project.resource_groups.join(", ")}" if project.azure?
     puts "slack_channel: #{project.slack_channel}"
@@ -61,7 +61,7 @@ def add_or_update_project(action=nil)
     add_project
   elsif action == "list"
     formatter = NoMethodMissingFormatter.new
-    tp ProjectFactory.new().all_projects_as_type, :id, :name, :host, :budget, :start_date, :end_date,
+    tp ProjectFactory.new().all_projects_as_type, :id, :name, :host, :current_budget, :start_date, :end_date,
     :slack_channel, {regions: {:display_method => :describe_regions, formatters: [formatter]}},
     {resource_groups: {:display_method => :describe_resource_groups, formatters: [formatter]}}, {filter_level: {formatters: [formatter]}}
     puts
@@ -78,7 +78,7 @@ def update_attributes(project)
   while !valid
     puts "What would you like to update (for security related attributes please select metadata)? "
     attribute = gets.chomp
-    if project.respond_to?(attribute.downcase)
+    if project.respond_to?(attribute.downcase) || attribute == "budget"
       valid = true
     else
       puts "That is not a valid attribute for this project. Please try again."
@@ -89,6 +89,8 @@ def update_attributes(project)
     update_regions(project)
   elsif attribute == "resource_groups" || attribute == "resource groups"
     update_resource_groups(project)
+  elsif attribute == "budget"
+    add_budget(project)
   else
     if attribute == "metadata"
       metadata = JSON.parse(project.metadata)
@@ -335,10 +337,8 @@ def add_project
     end
   end
   
-  print "Start date (YYYY-MM-DD): "
-  attributes[:start_date] = gets.chomp
   print "Budget (c.u./month): "
-  attributes[:budget] = gets.chomp
+  budget = gets.chomp
   print "Slack Channel: "
   attributes[:slack_channel] = gets.chomp
 
@@ -433,6 +433,8 @@ def add_project
     valid = project.valid?
   end
   project.save
+
+  Budget.create(project_id: project.id, amount: budget, effective_at: project.start_date, timestamp: Time.now)
   puts "Project #{project.name} created"
   
   stop = false
@@ -461,6 +463,34 @@ def validate_credentials(project)
   project = @factory.as_type(project)
   project.validate_credentials
   puts
+end
+
+def add_budget(project)
+  valid = false
+  while !valid
+    print "Budget amount (c.u./month): "
+    amount = gets.chomp
+    valid = begin
+      !!Integer(amount, 10)
+    rescue ArgumentError, TypeError
+      false
+    end
+    puts "Please enter a number" if !valid
+  end
+
+  valid_date = false
+  while !valid_date
+    print "Effective at (YYYY-MM-DD): "
+    valid_date = begin
+      Date.parse(gets.chomp)
+    rescue ArgumentError
+      false
+    end
+    puts "Invalid date. Please ensure it is in the format YYYY-MM-DD" if !valid_date
+  end
+  budget = Budget.new(project_id: project.id, amount: amount, effective_at: valid_date, timestamp: Time.now)
+  budget.save!
+  puts "Budget created"
 end
 
 # for table print

--- a/models/aws_project.rb
+++ b/models/aws_project.rb
@@ -209,7 +209,7 @@ class AwsProject < Project
       daily_future_cu = (future_costs * CostLog::USD_GBP_CONVERSION * 24 * 10 * 1.25).ceil
       total_future_cu = (daily_future_cu + fixed_daily_cu_cost).ceil
 
-      remaining_budget = self.budget.to_i - total_costs
+      remaining_budget = self.current_budget.to_i - total_costs
       remaining_days = remaining_budget / (daily_future_cu + fixed_daily_cu_cost)
       instances_date = logs.first ? Time.parse(logs.first.timestamp) : (date == DEFAULT_DATE ? Time.now : date + 0.5)
       time_lag = (instances_date.to_date - date).to_i
@@ -220,7 +220,7 @@ class AwsProject < Project
       msg = [
       "#{date_warning if date_warning}",
       ":calendar: \t\t\t\t Weekly Report for #{self.name} \t\t\t\t :calendar:",
-      "*Monthly Budget:* #{self.budget} compute units",
+      "*Monthly Budget:* #{self.current_budget} compute units",
       "*Compute Costs for #{date_range}:* #{compute_costs} compute units",
       "*Data Egress Costs for #{date_range}:* #{data_egress_costs} compute units (#{data_egress_amount} GB)",
       "*Total Costs for #{date_range}:* #{total_costs} compute units",

--- a/models/azure_project.rb
+++ b/models/azure_project.rb
@@ -249,7 +249,7 @@ class AzureProject < Project
       daily_future_cu = (future_costs * 24 * 10 * 1.25).ceil
       total_future_cu = (daily_future_cu + fixed_daily_cu_cost).ceil
 
-      remaining_budget = self.budget.to_i - total_costs
+      remaining_budget = current_budget.to_i - total_costs
       remaining_days = remaining_budget / (daily_future_cu + fixed_daily_cu_cost)
       instances_date = logs.first ? Time.parse(logs.first.timestamp) : (date == DEFAULT_DATE ? Time.now : date + 0.5)
       time_lag = (instances_date.to_date - date).to_i
@@ -260,7 +260,7 @@ class AzureProject < Project
       msg = [
       "#{date_warning if date_warning}",
       ":calendar: \t\t\t\t Weekly Report for #{self.name} \t\t\t\t :calendar:",
-      "*Monthly Budget:* #{self.budget} compute units",
+      "*Monthly Budget:* #{current_budget} compute units",
       "*Compute Costs for #{date_range}:* #{compute_costs} compute units",
       "*Data Egress Costs for #{date_range}:* #{data_out_cost} compute units (#{data_out_amount.ceil(2)} GB)",
       "*Total Costs for #{date_range}:* #{total_costs} compute units",

--- a/models/budget.rb
+++ b/models/budget.rb
@@ -32,8 +32,7 @@ ActiveRecord::Base.establish_connection(adapter: 'sqlite3', database: 'db/cost_t
 class Budget < ActiveRecord::Base
   belongs_to :project
   default_scope { order(:effective_at, timestamp: :asc) }
-  validates :amount, numericality: true
-  validates :amount, presence: true
+  validates :amount, numericality: true, presence: true
   validates :effective_at, presence: true
   validate :effective_at_valid, on: [:update, :create]
 

--- a/models/budget.rb
+++ b/models/budget.rb
@@ -31,7 +31,7 @@ ActiveRecord::Base.establish_connection(adapter: 'sqlite3', database: 'db/cost_t
 
 class Budget < ActiveRecord::Base
   belongs_to :project
-  default_scope { order(:effective_at, timestamp: :desc) }
+  default_scope { order(:effective_at, timestamp: :asc) }
   validates :amount, numericality: true
   validates :amount, presence: true
   validates :effective_at, presence: true

--- a/models/budget.rb
+++ b/models/budget.rb
@@ -1,0 +1,47 @@
+#==============================================================================
+# Copyright (C) 2020-present Alces Flight Ltd.
+#
+# This file is part of cloud-cost-reporter.
+#
+# This program and the accompanying materials are made available under
+# the terms of the Eclipse Public License 2.0 which is available at
+# <https://www.eclipse.org/legal/epl-2.0>, or alternative license
+# terms made available by Alces Flight Ltd - please direct inquiries
+# about licensing to licensing@alces-flight.com.
+#
+# cloud-cost-reporter is distributed in the hope that it will be useful, but
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, EITHER EXPRESS OR
+# IMPLIED INCLUDING, WITHOUT LIMITATION, ANY WARRANTIES OR CONDITIONS
+# OF TITLE, NON-INFRINGEMENT, MERCHANTABILITY OR FITNESS FOR A
+# PARTICULAR PURPOSE. See the Eclipse Public License 2.0 for more
+# details.
+#
+# You should have received a copy of the Eclipse Public License 2.0
+# along with cloud-cost-reporter. If not, see:
+#
+#  https://opensource.org/licenses/EPL-2.0
+#
+# For more information on cloud-cost-reporter, please visit:
+# https://github.com/openflighthpc/cloud-cost-reporter
+#==============================================================================
+
+require 'active_record'
+
+ActiveRecord::Base.establish_connection(adapter: 'sqlite3', database: 'db/cost_tracker.sqlite3')
+
+class Budget < ActiveRecord::Base
+  belongs_to :project
+  default_scope { order(:effective_at, timestamp: :desc) }
+  validates :amount, numericality: true
+  validates :amount, presence: true
+  validates :effective_at, presence: true
+  validate :effective_at_valid, on: [:update, :create]
+
+  def effective_at_valid
+    begin
+      Date.parse(self.effective_at)
+    rescue ArgumentError
+      errors.add(:effective_at, "Must be a valid date")
+    end
+  end
+end

--- a/models/project.rb
+++ b/models/project.rb
@@ -78,7 +78,7 @@ class Project < ActiveRecord::Base
   def current_budget
     return 0 if !active?
 
-    latest = self.budgets.where(:effective_at <= Date.today).last
+    latest = self.budgets.where("effective_at <= ? ", Date.today).last
     latest ? latest.amount : 0
   end
 


### PR DESCRIPTION
Aims to resolve #63

- Projects no longer have a `budget` attribute, but a collection of `Budget` objects
- Each `Budget` has a `project_id`, `amount`, `effective_at` date and `timestamp`
- This allows for tracking of changes to a budget, primarily for use by the `cloud-cost-visualiser` project
- When creating a new project as part of `manage_projects.rb` a `Budget` will now be created with an `effective_at` set as the project's `start_date`
- When updating a project's budget in `manage_projects.rb` this will create a new `Budget` with the specified amount and date
- Once merged, parallel changes will be required in the `cloud-cost-visualiser` project

**Note:** For existing copies of this application, the file `db/generate_budgets.rb` **must** be run to update the database