### PR TITLE
Record Azure instance sizes & AWS prices and instance sizes

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,3 +2,4 @@
 db/test_data.rb
 azure_prices.txt
 azure_sizes.txt
+aws_instance_details.txt

--- a/.gitignore
+++ b/.gitignore
@@ -1,5 +1,5 @@
 /db/*.sqlite3
 db/test_data.rb
 azure_prices.txt
-azure_sizes.txt
+azure_instance_sizes.txt
 aws_instance_details.txt

--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,4 @@
 /db/*.sqlite3
 db/test_data.rb
 azure_prices.txt
+azure_sizes.txt

--- a/Rakefile
+++ b/Rakefile
@@ -20,3 +20,8 @@ desc 'Get latest azure instance sizes'
 task :azure_instance_sizes do
   system("ruby get_latest_azure_instance_sizes.rb")
 end
+
+desc 'Get latest aws instance sizes and prices'
+task :aws_instance_info do
+  system("ruby get_latest_aws_instance_info.rb")
+end

--- a/Rakefile
+++ b/Rakefile
@@ -10,3 +10,13 @@ desc 'Run weekly reports'
 task :weekly_reports do
   system("SLACK_TOKEN=#{slack_token} ruby weekly_reports.rb all latest slack")
 end
+
+desc 'Get latest azure prices'
+task :azure_prices do
+  system("ruby get_latest_azure_prices.rb")
+end
+
+desc 'Get latest azure instance sizes'
+task :azure_instance_sizes do
+  system("ruby get_latest_azure_instance_sizes.rb")
+end

--- a/config/schedule.rb
+++ b/config/schedule.rb
@@ -23,6 +23,11 @@ every :day, at: '12pm' do
   rake "daily_reports"
 end
 
+every :day, at: '12am' do
+  rake "azure_prices"
+  rake "azure_instance_sizes"
+end
+
 every :monday, at: '12pm' do
   rake "weekly_reports"
 end

--- a/config/schedule.rb
+++ b/config/schedule.rb
@@ -26,6 +26,7 @@ end
 every :day, at: '12am' do
   rake "azure_prices"
   rake "azure_instance_sizes"
+  rake "aws_instance_info"
 end
 
 every :monday, at: '12pm' do

--- a/db/add_instance_mappings.rb
+++ b/db/add_instance_mappings.rb
@@ -47,5 +47,5 @@ InstanceMapping.create(instance_type: "Standard_NC6s_v3", customer_facing_name: 
 InstanceMapping.create(instance_type: "Standard_NC24s_v3", customer_facing_name: "GPU (Medium)")
 InstanceMapping.create(instance_type: "Standard_E2_v4", customer_facing_name: "Mem (Small)")
 InstanceMapping.create(instance_type: "Standard_E4_v4", customer_facing_name: "Mem (Medium)")
-InstanceMapping.create(instance_type: "Standard_E8_v2", customer_facing_name: "Mem (Large)")
+InstanceMapping.create(instance_type: "Standard_E8_v4", customer_facing_name: "Mem (Large)")
 InstanceMapping.create(instance_type: "Standard_B2s", customer_facing_name: "General (Small)")

--- a/get_latest_aws_instance_info.rb
+++ b/get_latest_aws_instance_info.rb
@@ -27,4 +27,10 @@
 
 require_relative './models/aws_project.rb'
 
-AwsProject.get_aws_instance_info
+# Need AWS credentials to get instance list, so use a project in database.
+project = AwsProject.where(host: 'azure').first
+if !project
+  puts "No AWS projects in database to retrieve instances details"
+else
+  project.get_aws_instance_info
+end

--- a/get_latest_aws_instance_info.rb
+++ b/get_latest_aws_instance_info.rb
@@ -1,0 +1,30 @@
+#==============================================================================
+# Copyright (C) 2020-present Alces Flight Ltd.
+#
+# This file is part of cloud-cost-reporter.
+#
+# This program and the accompanying materials are made available under
+# the terms of the Eclipse Public License 2.0 which is available at
+# <https://www.eclipse.org/legal/epl-2.0>, or alternative license
+# terms made available by Alces Flight Ltd - please direct inquiries
+# about licensing to licensing@alces-flight.com.
+#
+# cloud-cost-reporter is distributed in the hope that it will be useful, but
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, EITHER EXPRESS OR
+# IMPLIED INCLUDING, WITHOUT LIMITATION, ANY WARRANTIES OR CONDITIONS
+# OF TITLE, NON-INFRINGEMENT, MERCHANTABILITY OR FITNESS FOR A
+# PARTICULAR PURPOSE. See the Eclipse Public License 2.0 for more
+# details.
+#
+# You should have received a copy of the Eclipse Public License 2.0
+# along with cloud-cost-reporter. If not, see:
+#
+#  https://opensource.org/licenses/EPL-2.0
+#
+# For more information on cloud-cost-reporter, please visit:
+# https://github.com/openflighthpc/cloud-cost-reporter
+#==============================================================================
+
+require_relative './models/aws_project.rb'
+
+AwsProject.get_aws_instance_info

--- a/get_latest_azure_instance_sizes.rb
+++ b/get_latest_azure_instance_sizes.rb
@@ -1,0 +1,36 @@
+#==============================================================================
+# Copyright (C) 2020-present Alces Flight Ltd.
+#
+# This file is part of cloud-cost-reporter.
+#
+# This program and the accompanying materials are made available under
+# the terms of the Eclipse Public License 2.0 which is available at
+# <https://www.eclipse.org/legal/epl-2.0>, or alternative license
+# terms made available by Alces Flight Ltd - please direct inquiries
+# about licensing to licensing@alces-flight.com.
+#
+# cloud-cost-reporter is distributed in the hope that it will be useful, but
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, EITHER EXPRESS OR
+# IMPLIED INCLUDING, WITHOUT LIMITATION, ANY WARRANTIES OR CONDITIONS
+# OF TITLE, NON-INFRINGEMENT, MERCHANTABILITY OR FITNESS FOR A
+# PARTICULAR PURPOSE. See the Eclipse Public License 2.0 for more
+# details.
+#
+# You should have received a copy of the Eclipse Public License 2.0
+# along with cloud-cost-reporter. If not, see:
+#
+#  https://opensource.org/licenses/EPL-2.0
+#
+# For more information on cloud-cost-reporter, please visit:
+# https://github.com/openflighthpc/cloud-cost-reporter
+#==============================================================================
+
+require_relative './models/azure_project.rb'
+
+# Need Azure credentials to get instance list, so use a project in database.
+project = AzureProject.where(host: 'azure').first
+if !project
+  puts "No Azure projects in database to retrieve price list"
+else
+  project.get_instance_sizes
+end

--- a/models/aws_project.rb
+++ b/models/aws_project.rb
@@ -511,6 +511,107 @@ class AwsProject < Project
     @explorer.get_cost_and_usage(data_out_query(date))
   end
 
+  def get_aws_instance_info
+    regions = InstanceLog.where(host: "AWS").select(:region).distinct.pluck(:region).sort
+
+    timestamp = begin
+      Date.parse(File.open('aws_instance_details2.txt').first) 
+    rescue ArgumentError, Errno::ENOENT
+      false
+    end
+    existing_regions = begin
+      File.open('aws_instance_details2.txt').first(2).last.chomp
+    rescue Errno::ENOENT 
+      false
+    end
+
+    if timestamp == false || Date.today - timestamp >= 1 || existing_regions == false || existing_regions != regions.to_s
+      regions.each.with_index do |region, index|
+        if index == 0
+          File.write('aws_instance_details2.txt', "#{Time.now}\n")
+          File.write('aws_instance_details2.txt', "#{regions}\n", mode: "a")
+        end
+        first = true
+        results = nil
+        while first || results&.next_token
+          results = @pricing_checker.get_products(general_pricing_query(region, results&.next_token))
+          results.price_list.each do |result|
+            details = JSON.parse(result)
+            attributes = details["product"]["attributes"]
+            price = details["terms"]["OnDemand"]
+            price = price[price.keys[0]]["priceDimensions"]
+            price = price[price.keys[0]]["pricePerUnit"]["USD"].to_f
+            mem = attributes["memory"].gsub(" GiB", "")
+            info = {
+              instance_type: attributes["instanceType"],
+              location: region, 
+              price_per_hour: price,
+              cpu: attributes["vcpu"].to_i,
+              mem: mem.to_f,
+              gpu: attributes["gpu"] ? attributes["gpu"].to_i : 0
+            }
+            File.write('aws_instance_details2.txt', "#{info.to_json}\n", mode: 'a')
+            first = false
+          end
+        end
+      end
+    end
+  end
+
+  def self.get_aws_instance_info
+    regions = InstanceLog.where(host: "AWS").select(:region).distinct.pluck(:region).sort
+
+    timestamp = begin
+      Date.parse(File.open('aws_instance_details.txt').first) 
+    rescue ArgumentError, Errno::ENOENT
+      false
+    end
+    existing_regions = begin
+      File.open('aws_instance_details.txt').first(2).last.chomp
+    rescue Errno::ENOENT 
+      false
+    end
+
+    if timestamp == false || Date.today - timestamp >= 1 || existing_regions == false || existing_regions != regions.to_s
+      regions.each_with_index do |region, i|
+        uri = "https://pricing.us-east-1.amazonaws.com/offers/v1.0/aws/AmazonEC2/current/#{region}/index.csv"
+        response = HTTParty.get(uri)
+
+        if response.success?
+          if i == 0
+            File.write('aws_instance_details.txt', "#{Time.now}\n")
+            File.write('aws_instance_details.txt', "#{regions}\n", mode: "a")
+          end
+          response.each_line.with_index do |entry, j|
+            if j > 5
+              details = entry.split(",")
+              if details[3] == '"OnDemand"' && details[36] == '"Shared"' && details[38] == '"Linux"' && 
+                 details[47].include?("BoxUsage") && details[77] == '"NA"'
+                gpu = details[54].gsub('"', '')
+                gpu = gpu == '' ? 0 : gpu.to_i
+                mem = details[25].gsub('"', '').gsub(' GiB', '')
+                mem = mem.to_f
+                cpu = details[22].gsub('"', '')
+                cpu = cpu.to_i
+                price = details[9].gsub('"', '')
+                price = price.to_f
+                info = {
+                  instance_type: details[19].gsub('"', ''), location: region, 
+                  price_per_hour: price, cpu: cpu,
+                  mem: mem, gpu: gpu
+                }
+                File.write("aws_instance_details.txt", info.to_json, mode: "a")
+                File.write("aws_instance_details.txt", "\n", mode: "a")
+              end
+            end
+          end
+        else
+          raise AwsApiError.new("Error obtaining latest AWS instance list. Error code #{response.code}.\n#{response}")
+        end
+      end
+    end
+  end
+
   private
 
   def compute_cost_query(start_date, end_date=(start_date + 1), granularity="DAILY")
@@ -683,6 +784,42 @@ class AwsProject < Project
     }
   end
 
+  def general_pricing_query(region, token=nil)
+    details = {
+      service_code: "AmazonEC2",
+      filters: [ 
+        {
+          field: "location", 
+          type: "TERM_MATCH", 
+          value: @@region_mappings[region], 
+        },
+        {
+          field: "tenancy",
+          type: "TERM_MATCH",
+          value: "shared"
+        },
+        {
+          field: "capacitystatus",
+          type: "TERM_MATCH",
+          value: "UnusedCapacityReservation"
+        },
+        {
+          field: "operatingSystem",
+          type: "TERM_MATCH",
+          value: "linux"
+        },
+        {
+          field: "preInstalledSW",
+          type: "TERM_MATCH", 
+          value: "NA"
+        }
+     ], 
+     format_version: "aws_v1"
+    }
+    details[:next_token] = token if token
+    details
+  end
+
   def project_instances_query
     if filter_level == "tag"
       {
@@ -725,4 +862,7 @@ class AwsProject < Project
 end
 
 class AwsSdkError < StandardError
+end
+
+class AwsSpiError < StandardError
 end

--- a/models/aws_project.rb
+++ b/models/aws_project.rb
@@ -531,11 +531,11 @@ class AwsProject < Project
           File.write('aws_instance_details.txt', "#{Time.now}\n")
           File.write('aws_instance_details.txt', "#{regions}\n", mode: "a")
         end
-        first = true
+        first_query = true
         results = nil
-        while first || results&.next_token
+        while first_query || results&.next_token
           begin
-            results = @pricing_checker.get_products(general_pricing_query(region, results&.next_token))
+            results = @pricing_checker.get_products(instances_info_query(region, results&.next_token))
           rescue Aws::EC2::Errors::ServiceError => error
             raise AwsSdkError.new("Unable to determine AWS instances in region #{region}. #{error}")
           end
@@ -555,8 +555,8 @@ class AwsProject < Project
               gpu: attributes["gpu"] ? attributes["gpu"].to_i : 0
             }
             File.write('aws_instance_details.txt', "#{info.to_json}\n", mode: 'a')
-            first = false
           end
+          first_query = false
         end
       end
     end
@@ -734,7 +734,7 @@ class AwsProject < Project
     }
   end
 
-  def general_pricing_query(region, token=nil)
+  def instances_info_query(region, token=nil)
     details = {
       service_code: "AmazonEC2",
       filters: [ 

--- a/models/aws_project.rb
+++ b/models/aws_project.rb
@@ -536,7 +536,7 @@ class AwsProject < Project
         while first_query || results&.next_token
           begin
             results = @pricing_checker.get_products(instances_info_query(region, results&.next_token))
-          rescue Aws::EC2::Errors::ServiceError => error
+          rescue Aws::Pricing::Errors::ServiceError => error
             raise AwsSdkError.new("Unable to determine AWS instances in region #{region}. #{error}")
           end
           results.price_list.each do |result|

--- a/models/azure_project.rb
+++ b/models/azure_project.rb
@@ -600,7 +600,8 @@ class AzureProject < Project
         File.write('azure_instance_sizes.txt', "#{Time.now}\n")
         File.write('azure_instance_sizes.txt', "#{regions}\n", mode: "a")
         response["value"].each do |instance|
-          if instance["resourceType"] == "virtualMachines" && regions.include?(instance["locations"][0])
+          if instance["resourceType"] == "virtualMachines" && regions.include?(instance["locations"][0]) &&
+            instance["name"].include?("Standard")
             details = {
               instance_type: instance["name"], instance_family: instance["family"],
               location: instance["locations"][0],

--- a/models/azure_project.rb
+++ b/models/azure_project.rb
@@ -597,8 +597,8 @@ class AzureProject < Project
       )
 
       if response.success?
-        File.write('azure_sizes.txt', "#{Time.now}\n")
-        File.write('azure_sizes.txt', "#{regions}\n", mode: "a")
+        File.write('azure_instance_sizes.txt', "#{Time.now}\n")
+        File.write('azure_instance_sizes.txt', "#{regions}\n", mode: "a")
         response["value"].each do |instance|
           if instance["resourceType"] == "virtualMachines" && regions.include?(instance["locations"][0])
             details = {
@@ -615,8 +615,8 @@ class AzureProject < Project
                 details[:gpu] = capability["value"].to_i
               end
             end
-            File.write("azure_sizes.txt", details.to_json, mode: "a")
-            File.write("azure_sizes.txt", "\n", mode: "a")
+            File.write("azure_instance_sizes.txt", details.to_json, mode: "a")
+            File.write("azure_instance_sizes.txt", "\n", mode: "a")
           end
         end
       else

--- a/models/azure_project.rb
+++ b/models/azure_project.rb
@@ -608,11 +608,11 @@ class AzureProject < Project
               cpu: 0, gpu: 0, mem: 0}
             instance["capabilities"].each do |capability|
               if capability["name"] == "MemoryGB"
-                details[:mem] = capability["value"]
+                details[:mem] = capability["value"].to_f
               elsif capability["name"] == "vCPUsAvailable"
-                details[:cpu] = capability["value"]
+                details[:cpu] = capability["value"].to_i
               elsif capability["name"] == "GPUs"
-                details[:gpu] = capability["value"]
+                details[:gpu] = capability["value"].to_i
               end
             end
             File.write("azure_sizes.txt", details.to_json, mode: "a")

--- a/models/azure_project.rb
+++ b/models/azure_project.rb
@@ -30,7 +30,6 @@ require_relative 'project'
 
 class AzureProject < Project
   @@prices = {}
-  @@sizes = {}
   @@region_mappings = {}
 
   after_initialize :construct_metadata
@@ -590,8 +589,8 @@ class AzureProject < Project
     end
 
     if timestamp == false || Date.today - timestamp >= 1 || existing_regions == false || existing_regions != regions.to_s
-    update_bearer_token
-    uri = "https://management.azure.com/subscriptions/#{subscription_id}/providers/Microsoft.Compute/skus?api-version=2019-04-01"
+      update_bearer_token
+      uri = "https://management.azure.com/subscriptions/#{subscription_id}/providers/Microsoft.Compute/skus?api-version=2019-04-01"
       response = HTTParty.get(
         uri,
         headers: { 'Authorization': "Bearer #{bearer_token}" }
@@ -605,7 +604,8 @@ class AzureProject < Project
             details = {
               instance_type: instance["name"], instance_family: instance["family"],
               location: instance["locations"][0],
-              cpu: 0, gpu: 0, mem: 0}
+              cpu: 0, gpu: 0, mem: 0
+            }
             instance["capabilities"].each do |capability|
               if capability["name"] == "MemoryGB"
                 details[:mem] = capability["value"].to_f

--- a/models/azure_project.rb
+++ b/models/azure_project.rb
@@ -578,12 +578,12 @@ class AzureProject < Project
     regions = InstanceLog.where(host: "Azure").select(:region).distinct.pluck(:region).sort
 
     timestamp = begin
-      Date.parse(File.open('azure_sizes.txt').first) 
+      Date.parse(File.open('azure_instance_sizes.txt').first) 
     rescue ArgumentError, Errno::ENOENT
       false
     end
     existing_regions = begin
-      File.open('azure_sizes.txt').first(2).last.chomp
+      File.open('azure_instance_sizes.txt').first(2).last.chomp
     rescue Errno::ENOENT 
       false
     end
@@ -595,7 +595,7 @@ class AzureProject < Project
         uri,
         headers: { 'Authorization': "Bearer #{bearer_token}" }
       )
-
+      
       if response.success?
         File.write('azure_instance_sizes.txt', "#{Time.now}\n")
         File.write('azure_instance_sizes.txt', "#{regions}\n", mode: "a")

--- a/models/azure_project.rb
+++ b/models/azure_project.rb
@@ -606,10 +606,11 @@ class AzureProject < Project
               location: instance["locations"][0],
               cpu: 0, gpu: 0, mem: 0
             }
+
             instance["capabilities"].each do |capability|
               if capability["name"] == "MemoryGB"
                 details[:mem] = capability["value"].to_f
-              elsif capability["name"] == "vCPUsAvailable"
+              elsif capability["name"] == "vCPUs"
                 details[:cpu] = capability["value"].to_i
               elsif capability["name"] == "GPUs"
                 details[:gpu] = capability["value"].to_i


### PR DESCRIPTION
Aims to resolve #65 and relates to https://github.com/openflighthpc/cloud-cost-visualiser/issues/9

- Retrieves and records list of available Azure instances. Including their location, CPUs, memory and GPUs. Saved to the file `azure_instance_sizes.txt`
- Retrieves and records list of available AWS instances. Including their region, CPUs, memory, GPUs and cost per hour. Saved in `aws_instance_details.txt`
- Data is stored in JSON format
- Only data for locations/ regions used by existing projects
- AWS instance details only retrieved for instances running Linux, with shared tenancy and no special software installed
- New queries are only made if no such query made so far today, or a new region added since the last query
- Includes helper files for updating these on demand by running  `ruby get_latest_azure_instance_sizes.rb` and `ruby get_latest_aws_instance_info.rb`
- Includes `rake` tasks and entries in `config/schedule.rb` for running these at midnight each day via crontab. These can be added to the system's crontab by running `whenever --update-crontab`

**Implementation Detail**
- Azure instance sizes are retrieved using the `skus API`
- This returns data for all available locations for the given subscription, so these are filtered after retrieval
- AWS pricing and instances sizes are retrieved using the `Pricing SDK`
- This returns either all regions' data, or data for one region only. As large result sets are paginated (requiring further follow up queries), it is more efficient to make a query for each relevant region and amalgamate the results
- These additions require an AWS/ Azure Project respectively in the database with valid credentials to run
- Not explored here, but this may allow for possible efficiency gains in the AWS weekly report, by using data in `aws_instance_details.txt` instead of making individual pricing queries (which also involve a small cost)
- It was also explored retrieving AWS instance data without credentials using their `Bulk API`. However this downloads a very large file and is 100+ times slower than using the pricing SDK
 