### PR TITLE
Accommodate slow Azure API responses

### DIFF
--- a/daily_reports.rb
+++ b/daily_reports.rb
@@ -82,7 +82,7 @@ if ARGV[0] && ARGV[0] != "all"
   begin
     project.daily_report(date, slack, text, rerun, verbose, customer_facing)
   rescue AzureApiError, AwsSdkError => e
-    puts "Generation of weekly report for project #{project.name} stopped due to error: "
+    puts "Generation of daily report for project #{project.name} stopped due to error: "
     puts e
   end
 else


### PR DESCRIPTION
Aims to resolve #69

- Responses from Azure API queries are generally slow, and occasionally so slow they exceed the Ruby default HTTP timeout of 60 seconds, causing `Net::ReadTimeout` errors to be raised
- This PR therefore increases the timeout for HTTP requests to these APIs, from the default of 60 seconds to 180 seconds
- Have also seen the Azure API respond occasionally and unpredictably with a server side 504 (gateway timeout) error
- If a 504 is returned (or a `Net::ReadTimeout` error is still raised) will now make up to 2 further query attempts

Was unable to manually replicate the errors described in #69 (as response times/ 504s determined by Azure API), so simulated timeouts/ responses used for testing.