### PR TITLE
Correct host name for aws instance details script

### DIFF
--- a/get_latest_aws_instance_info.rb
+++ b/get_latest_aws_instance_info.rb
@@ -28,7 +28,7 @@
 require_relative './models/aws_project.rb'
 
 # Need AWS credentials to get instance list, so use a project in database.
-project = AwsProject.where(host: 'azure').first
+project = AwsProject.where(host: 'aws').first
 if !project
   puts "No AWS projects in database to retrieve instances details"
 else


### PR DESCRIPTION
Fixes typo/ copy & paste error in script for retrieving aws instance details (required by the cloud-cost-visualiser), so that it uses the correct project type's credentials.