### PR TITLE
Set default azure region when getting files

### DIFF
--- a/models/azure_project.rb
+++ b/models/azure_project.rb
@@ -587,7 +587,10 @@ class AzureProject < Project
   end
 
   def get_prices
-    regions = InstanceLog.where(host: "Azure").select(:region).distinct.pluck(:region).sort
+    regions = InstanceLog.where(host: "Azure").select(:region).distinct.pluck(:region)
+    regions << "uksouth" if !regions.include?("uksouth")
+    regions.sort!
+
     regions.map! do |region|
       value = @@region_mappings[region]
       puts "No region mapping for #{region}, please update 'azure_region_names.txt' and rerun" and return if !value
@@ -642,7 +645,9 @@ class AzureProject < Project
   end
 
   def get_instance_sizes
-    regions = InstanceLog.where(host: "Azure").select(:region).distinct.pluck(:region).sort
+    regions = InstanceLog.where(host: "Azure").select(:region).distinct.pluck(:region)
+    regions << "uksouth" if !regions.include?("uksouth")
+    regions.sort!
 
     timestamp = begin
       Date.parse(File.open('azure_instance_sizes.txt').first) 

--- a/models/azure_project.rb
+++ b/models/azure_project.rb
@@ -587,8 +587,7 @@ class AzureProject < Project
   end
 
   def get_prices
-    regions = InstanceLog.where(host: "Azure").select(:region).distinct.pluck(:region)
-    regions << "uksouth" if !regions.include?("uksouth")
+    regions = InstanceLog.where(host: "Azure").select(:region).distinct.pluck(:region) | ["uksouth"]
     regions.sort!
 
     regions.map! do |region|
@@ -645,8 +644,7 @@ class AzureProject < Project
   end
 
   def get_instance_sizes
-    regions = InstanceLog.where(host: "Azure").select(:region).distinct.pluck(:region)
-    regions << "uksouth" if !regions.include?("uksouth")
+    regions = InstanceLog.where(host: "Azure").select(:region).distinct.pluck(:region) | ["uksouth"]
     regions.sort!
 
     timestamp = begin


### PR DESCRIPTION
In the cloud-cost-visualiser an Azure project's regions are determined by the locations of their instance logs (as Azure treats subscriptions as global). If they have no instance logs yet, we default them to UK South.

When retrieving Azure pricing and instance size data in this application, we only save the data for regions that match existing instance logs (to save space and reduce read/write times). This PR ensures that UK South is always included when retrieving/ saving such data, even if no instance log exists in that region, so that this information is available to such a project in the visualiser application.