### PR TITLE
Use instances to estimate costs on forecast days in the past

### DIFF
--- a/models/aws_project.rb
+++ b/models/aws_project.rb
@@ -224,7 +224,7 @@ class AwsProject < Project
       daily_future_cu = (future_costs * CostLog::USD_GBP_CONVERSION * 24 * 10 * 1.25).ceil
       total_future_cu = (daily_future_cu + fixed_daily_cu_cost).ceil
 
-      remaining_budget = self.current_budget.to_i - total_costs - inbetween_costs
+      remaining_budget = self.current_budget.to_i - total_costs
       remaining_days = (remaining_budget - inbetween_costs) / (daily_future_cu + fixed_daily_cu_cost)
       enough = (date + remaining_days) >= (date >> 1).beginning_of_month
       date_range = "1 - #{(date).day} #{Date::MONTHNAMES[date.month]}"

--- a/models/azure_project.rb
+++ b/models/azure_project.rb
@@ -240,7 +240,22 @@ class AzureProject < Project
       compute_costs = (compute_costs * 10 * 1.25).ceil
 
       logs = self.instance_logs.where('timestamp LIKE ?', "%#{date == DEFAULT_DATE ? Date.today : date}%").where(compute: 1)
+      instances_date = logs.first ? Time.parse(logs.first.timestamp) : (date == DEFAULT_DATE ? Time.now : date + 0.5)
       update_prices
+
+      inbetween_costs = 0.0
+      inbetween_dates = ((date + 1.day)...instances_date.to_date).to_a
+      inbetween_dates.each do |date|
+        self.instance_logs.where('timestamp LIKE ?', "%#{date}%").where(compute: 1).each do |log|
+          if log.status.downcase == "available"
+            type = log.instance_type.gsub("Standard_", "").gsub("_", " ")
+            inbetween_costs += @@prices[@@region_mappings[log.region]][type][0]
+          end
+        end
+      end
+      inbetween_costs = (inbetween_costs * 24 * 10 * 1.25).ceil
+      inbetween_costs = (inbetween_costs + (fixed_daily_cu_cost * inbetween_dates.count)).ceil
+
       future_costs = 0.0
       logs.each do |log|
         if log.status.downcase == 'available'
@@ -252,10 +267,9 @@ class AzureProject < Project
       total_future_cu = (daily_future_cu + fixed_daily_cu_cost).ceil
 
       remaining_budget = current_budget.to_i - total_costs
-      remaining_days = remaining_budget / (daily_future_cu + fixed_daily_cu_cost)
-      instances_date = logs.first ? Time.parse(logs.first.timestamp) : (date == DEFAULT_DATE ? Time.now : date + 0.5)
+      remaining_days = (remaining_budget - inbetween_costs) / (daily_future_cu + fixed_daily_cu_cost)
       time_lag = (instances_date.to_date - date).to_i
-      enough = (date + remaining_days + time_lag) >= (date >> 1).beginning_of_month
+      enough = (date + remaining_days) >= (date >> 1).beginning_of_month
       date_range = "1 - #{(date).day} #{Date::MONTHNAMES[date.month]}"
       date_warning = date > Date.today - 3 ? "\nWarning: data takes roughly 72 hours to update, so these figures may be inaccurate\n" : nil
 
@@ -272,19 +286,23 @@ class AzureProject < Project
       "`#{usage}`\n",
       "The average cost for these compute nodes, in the above state, is about *#{daily_future_cu}* compute units per day.",
       "Other, fixed cluster costs are on average *#{fixed_daily_cu_cost}* compute units per day.\n",
-      "The total estimated requirement is therefore *#{total_future_cu}* compute units per day.\n",
+      "The total estimated requirement is therefore *#{total_future_cu}* compute units per day, from today.\n",
       "*Predicted Usage*"
       ]
 
       if remaining_budget < 0
         msg << ":awooga:The monthly budget *has been exceeded*:awooga:."
-      else
-        msg << "Based on the current usage, the remaining budget will be used up in *#{remaining_days}* days."
-        msg << "#{time_lag > 0 ? "As tracking is *#{time_lag}* days behind, t" : "T"}he budget is predicted to therefore be *#{enough ? "sufficient" : ":awooga:insufficient:awooga:"}* for the rest of the month."
+      end
+      if time_lag > 0
+        msg << "Estimated total combined costs for the previous #{inbetween_dates.count} days are *#{inbetween_costs}* compute units, based on instances running on those days.\n"
+      end
+      if remaining_budget > 0
+        msg << "Based on #{'this and ' if time_lag > 0 }the current usage, the remaining budget will be used up in *#{remaining_days}* days."
+        msg << "The budget is predicted to therefore be *#{enough ? "sufficient" : ":awooga:insufficient:awooga:"}* for the rest of the month."
       end
       if remaining_budget < 0 || !enough
         excess = remaining_budget - (total_future_cu * (date.end_of_month.day - date.day))
-        msg << "Based on current usage the budget will be exceeded by *#{excess}* compute units at the end of the month."
+         msg << "Based on #{'this and ' if time_lag > 0 && remaining_budget < 0}the current usage the budget will be exceeded by *#{excess}* compute units at the end of the month."
       end
       msg = msg.join("\n") + "\n"
 

--- a/models/azure_project.rb
+++ b/models/azure_project.rb
@@ -239,8 +239,8 @@ class AzureProject < Project
       compute_costs ||= 0.0
       compute_costs = (compute_costs * 10 * 1.25).ceil
 
-      logs = self.instance_logs.where('timestamp LIKE ?', "%#{date == DEFAULT_DATE ? Date.today : date}%").where(compute: 1)
-      instances_date = logs.first ? Time.parse(logs.first.timestamp) : (date == DEFAULT_DATE ? Time.now : date + 0.5)
+      latest_logs = self.instance_logs.where('timestamp LIKE ?', "%#{date == DEFAULT_DATE ? Date.today : date}%").where(compute: 1)
+      instances_date = latest_logs.first ? Time.parse(latest_logs.first.timestamp) : (date == DEFAULT_DATE ? Time.now : date + 0.5)
       update_prices
 
       inbetween_costs = 0.0
@@ -257,7 +257,7 @@ class AzureProject < Project
       inbetween_costs = (inbetween_costs + (fixed_daily_cu_cost * inbetween_dates.count)).ceil
 
       future_costs = 0.0
-      logs.each do |log|
+      latest_logs.each do |log|
         if log.status.downcase == 'available'
           type = log.instance_type.gsub("Standard_", "").gsub("_", " ")
           future_costs += @@prices[@@region_mappings[log.region]][type][0]


### PR DESCRIPTION
Aims to resolve #68

- Currently the weekly reports use the estimated compute costs for today's running instances for all forecasts, including for days in the past (i.e. yesterday and the day before, which don't yet have actual data)
- This PR instead estimates compute costs for forecast days in the past using the instances recorded as running on those specific days
- These costs are highlighted in the slack & text reports
- This brings it more in line with how forecasts are treated in the cloud-cost-visualiser

<img src="https://user-images.githubusercontent.com/59840834/101655670-c3f39700-3a39-11eb-97d6-b9ba4a58a0ae.png" height = "150px">

<img src="https://user-images.githubusercontent.com/59840834/101655681-c5bd5a80-3a39-11eb-9e8c-3f15db7f8962.png" height = "100px">

<img src="https://user-images.githubusercontent.com/59840834/101655690-c7871e00-3a39-11eb-8b51-f4f66fdf7587.png" height = "150px">
