### PR TITLE
Prevent blank project credentials and handle more AWS error types

### DIFF
--- a/manage_projects.rb
+++ b/manage_projects.rb
@@ -97,15 +97,12 @@ def update_attributes(project)
       keys = metadata.keys
       keys = keys - ["regions", "resource_groups", "bearer_token", "bearer_expiry"]
       puts "Possible keys: #{keys.join(", ")}"
-      print "Key name: "
-      key = gets.chomp
-      print 'Value: '
-      value = gets.chomp
+      key = get_non_blank("Key name", "Key")
+      value = get_non_blank("#{key} value", key)
       metadata[key] = value
       project.metadata = metadata.to_json
     else
-      print 'Value: '
-      value = gets.chomp
+      value = get_non_blank(attribute)
       project.write_attribute(attribute.to_sym, value)
     end
     valid = project.valid?
@@ -113,7 +110,7 @@ def update_attributes(project)
       project.errors.messages.each do |k, v|
         puts "#{k} #{v.join("; ")}"
         puts "Please enter new #{k}"
-        value = gets.chomp
+        value = get_non_blank(k)
         project.write_attribute(k, value)
       end
       valid = project.valid?
@@ -149,9 +146,6 @@ def update_attributes(project)
 end
 
 def update_regions(project)
-  metadata = JSON.parse(project.metadata)
-  regions = project.regions
-  puts "Regions: #{regions.join(", ")}"
   aws_regions = []
   file = File.open('aws_region_names.txt')
   file.readlines.each do |line|
@@ -161,13 +155,15 @@ def update_regions(project)
   stop = false
   valid = false
   while !stop
+    metadata = JSON.parse(project.metadata)
+    regions = project.regions
+    puts "Regions: #{regions.join(", ")}"
     while !valid
       puts "Add or delete region (add/delete)? "
       response = gets.chomp.downcase
       if response == "add"
         valid = true
-        print "Add region (e.g. eu-central-1): "
-        region = gets.chomp.downcase
+        region = get_non_blank("Add region (e.g. eu-central-1)", "Region")
         continue = false
         while !continue
           if !aws_regions.include?(region)
@@ -192,8 +188,7 @@ def update_regions(project)
           valid = true
           present = false
           while !present
-            print "Region to delete: "
-            to_delete = gets.chomp
+            to_delete = get_non_blank("Region to delete", "Region")
             present = regions.include?(to_delete)
             if present
               regions.delete(to_delete)
@@ -222,7 +217,6 @@ def update_regions(project)
       elsif action != "y"
         puts "Invalid option. Please try again"
       else
-        puts "Regions: #{regions.join(", ")}"
         stop = false
         yes_or_no = true
         valid = false
@@ -232,21 +226,18 @@ def update_regions(project)
 end
 
 def update_resource_groups(project)
-  metadata = JSON.parse(project.metadata)
-  resource_groups = project.resource_groups
-  puts "Resource groups: #{resource_groups.join(", ")}"
   stop = false
   valid = false
   while !stop
+    metadata = JSON.parse(project.metadata)
+    resource_groups = project.resource_groups
+    puts "Resource groups: #{resource_groups.join(", ")}"
     while !valid
       puts "Add or delete resource group (add/delete)? "
       response = gets.chomp.downcase
       if response == "add"
         valid = true
-        print "Add resource group: "
-        group = gets.chomp.downcase
-        continue = false
-        resource_groups << group
+        resource_groups << get_non_blank("Add resource group", "Resource group").downcase
         metadata[:resource_groups] = resource_groups.uniq
         project.metadata = metadata.to_json
         project.save!
@@ -256,8 +247,7 @@ def update_resource_groups(project)
           valid = true
           present = false
           while !present
-            print "Resource group to delete: "
-            to_delete = gets.chomp.downcase
+            to_delete = get_non_blank("Resource group to delete", "Resource group").downcase
             present = resource_groups.include?(to_delete)
             if present
               resource_groups.delete(to_delete)
@@ -286,7 +276,6 @@ def update_resource_groups(project)
       elsif action != "y"
         puts "Invalid option. Please try again"
       else
-        puts "Resource groups: #{resource_groups.join(", ")}"
         stop = false
         yes_or_no = true
         valid = false
@@ -337,16 +326,23 @@ def add_project
     end
   end
   
-  print "Budget (c.u./month): "
-  budget = gets.chomp
-  print "Slack Channel: "
-  attributes[:slack_channel] = gets.chomp
+  budget = nil
+  valid = false
+  while !valid
+    budget = get_non_blank("Budget amount (c.u./month)", "Budget")
+    valid = begin
+      Integer(budget, 10)
+    rescue ArgumentError, TypeError
+      false
+    end
+    puts "Please enter a number" if !valid
+  end
+  attributes[:slack_channel] = get_non_blank("Slack Channel", "Slack Channel")
 
   metadata = {}
   if attributes[:host].downcase == "aws"
     regions = []
-    print "Primary region (e.g. eu-west-2): "
-    regions << gets.chomp
+    regions << get_non_blank("Add region (e.g. eu-west-2)", "Region").downcase
     stop = false
     while !stop
       valid = false
@@ -363,17 +359,13 @@ def add_project
         end
       end
       if !stop
-        print "Additional region (e.g. eu-central-1): "
-        regions << gets.chomp
+        regions << get_non_blank("Additional region (e.g. eu-central-1)", "Region")
       end
     end
     metadata["regions"] = regions
-    print "Access Key Id: "
-    metadata["access_key_ident"] = gets.chomp
-    print "Secret Access Key: "
-    metadata["key"] = gets.chomp
-    print "Account Id number: "
-    metadata["account_id"] = gets.chomp
+    metadata["access_key_ident"] = get_non_blank("Access Key Id")
+    metadata["key"] = get_non_blank("Secret Access Key")
+    metadata["account_id"] = get_non_blank("Account Id Number")
     valid = false
     while !valid
       print "Filtering level (tag/account): "
@@ -386,17 +378,12 @@ def add_project
       end
     end
   else
-    print "Tenant Id: "
-    metadata["tenant_id"] = gets.chomp
-    print "Azure Client Id: "
-    metadata["client_id"] = gets.chomp
-    print "Subscription Id: "
-    metadata["subscription_id"] = gets.chomp
-    print "Client Secret: "
-    metadata["client_secret"] = gets.chomp
+    metadata["tenant_id"] = get_non_blank("Tenant Id")
+    metadata["client_id"] = get_non_blank("Azure Client Id")
+    metadata["subscription_id"] = get_non_blank("Subscription Id")
+    metadata["client_secret"] = get_non_blank("Client Secret")
     resource_groups = []
-    print "First resource group name: "
-    resource_groups << gets.chomp.downcase
+    resource_groups << get_non_blank("First resource group name", "Resource group").downcase
     stop = false
     while !stop
       valid = false
@@ -413,8 +400,7 @@ def add_project
         end
       end
       if !stop
-        print "Additional resource group name: "
-        resource_groups << gets.chomp.downcase
+        resource_groups << get_non_blank("Additional resource group name", "Resource group").downcase
       end
     end
     metadata["resource_groups"] = resource_groups
@@ -427,7 +413,7 @@ def add_project
     project.errors.messages.each do |k, v|
       puts "#{k} #{v.join("; ")}"
       puts "Please enter new #{k}"
-      value = gets.chomp
+      value = get_non_blank(k)
       project.write_attribute(k, value)
     end
     valid = project.valid?
@@ -468,8 +454,7 @@ end
 def add_budget(project)
   valid = false
   while !valid
-    print "Budget amount (c.u./month): "
-    amount = gets.chomp
+    amount = get_non_blank("Budget amount (c.u./month)", "Budget")
     valid = begin
       Integer(amount, 10)
     rescue ArgumentError, TypeError
@@ -491,6 +476,20 @@ def add_budget(project)
   budget = Budget.new(project_id: project.id, amount: amount, effective_at: valid_date, timestamp: Time.now)
   budget.save!
   puts "Budget created"
+end
+
+def get_non_blank(text, attribute=text)
+  valid = false
+  while !valid
+    print "#{text}: "
+    response = gets.strip
+    if response == ""
+      puts "#{attribute} must not be blank"
+    else
+      valid = true
+    end
+  end
+  response
 end
 
 # for table print

--- a/manage_projects.rb
+++ b/manage_projects.rb
@@ -181,7 +181,7 @@ def update_regions(project)
           end
         end
         regions << region
-        metadata[:regions] = regions.uniq.reject { |region| region.strip.empty? }
+        metadata[:regions] = regions.uniq
         project.metadata = metadata.to_json
         project.save!
         puts "Region added"
@@ -319,7 +319,7 @@ def add_project
   while !valid_date
     print "End date (YYYY-MM-DD). Press enter to leave blank: "
     date = gets.chomp
-    break if date == ""
+    break if date.empty?
     valid_date = begin
       Date.parse(date)
     rescue ArgumentError
@@ -489,7 +489,7 @@ def get_non_blank(text, attribute=text)
   while !valid
     print "#{text}: "
     response = gets.strip
-    if response == ""
+    if response.empty?
       puts "#{attribute} must not be blank"
     else
       valid = true

--- a/manage_projects.rb
+++ b/manage_projects.rb
@@ -176,10 +176,12 @@ def update_regions(project)
             else
               continue = true
             end
+          else
+            continue = true
           end
         end
         regions << region
-        metadata[:regions] = regions.uniq
+        metadata[:regions] = regions.uniq.reject { |region| region.strip.empty? }
         project.metadata = metadata.to_json
         project.save!
         puts "Region added"
@@ -188,7 +190,9 @@ def update_regions(project)
           valid = true
           present = false
           while !present
-            to_delete = get_non_blank("Region to delete", "Region")
+            # we want to allow blanks here so can delete if one (somehow) previously added
+            print "Region to delete: "
+            to_delete = gets.chomp
             present = regions.include?(to_delete)
             if present
               regions.delete(to_delete)
@@ -247,7 +251,9 @@ def update_resource_groups(project)
           valid = true
           present = false
           while !present
-            to_delete = get_non_blank("Resource group to delete", "Resource group").downcase
+            # we want to allow blanks here so can delete if one (somehow) previously added
+            print "Resource group to delete: "
+            to_delete = gets.chomp.downcase
             present = resource_groups.include?(to_delete)
             if present
               resource_groups.delete(to_delete)

--- a/models/aws_project.rb
+++ b/models/aws_project.rb
@@ -70,7 +70,6 @@ class AwsProject < Project
     @metadata = JSON.parse(self.metadata)
     Aws.config.update({region: "us-east-1"})
     @explorer = Aws::CostExplorer::Client.new(access_key_id: self.access_key_ident, secret_access_key: self.key)
-    @instances_checker = Aws::EC2::Client.new(access_key_id: self.access_key_ident, secret_access_key: self.key, region: self.regions.first)
     @pricing_checker = Aws::Pricing::Client.new(access_key_id: self.access_key_ident, secret_access_key: self.key)
     determine_region_mappings 
   end
@@ -88,23 +87,33 @@ class AwsProject < Project
   def validate_credentials
     puts "Validating AWS project credentials."
     valid = true
+ 
+    begin
+      @explorer = Aws::CostExplorer::Client.new(access_key_id: self.access_key_ident, secret_access_key: self.key)
+      @instances_checker = Aws::EC2::Client.new(access_key_id: self.access_key_ident, secret_access_key: self.key, region: self.regions.first)
+      @pricing_checker = Aws::Pricing::Client.new(access_key_id: self.access_key_ident, secret_access_key: self.key)
+    rescue Aws::Errors::MissingRegionError => error
+      puts "Unable to create AWS SDK objects due to missing region: #{error}"
+      return
+    end
+
     begin
       @explorer.get_cost_and_usage(compute_cost_query(DEFAULT_DATE))
-    rescue  Aws::CostExplorer::Errors::ServiceError => error
+    rescue  Aws::CostExplorer::Errors::ServiceError, Seahorse::Client::NetworkingError => error
       valid = false
       puts "Unable to connect to AWS Cost Explorer: #{error}"
     end
     
     begin
       @instances_checker.describe_instances(project_instances_query)
-    rescue Aws::EC2::Errors::ServiceError => error
+    rescue Aws::EC2::Errors::ServiceError, Aws::Errors::MissingRegionError, Seahorse::Client::NetworkingError => error
       valid = false
       puts "Unable to connect to AWS EC2: #{error}."
     end
 
     begin
       @pricing_checker.get_products(service_code: "AmazonEC2", format_version: "aws_v1", max_results: 1)
-    rescue Aws::Pricing::Errors::ServiceError => error
+    rescue Aws::Pricing::Errors::ServiceError, Seahorse::Client::NetworkingError => error
       valid = false
       puts "Unable to connect to AWS Pricing: #{error}"
     end
@@ -284,7 +293,7 @@ class AwsProject < Project
     if !compute_cost_log || rerun
       begin
         compute_cost = @explorer.get_cost_and_usage(compute_cost_query(date)).results_by_time[0][:total]["UnblendedCost"][:amount].to_f
-      rescue Aws::CostExplorer::Errors::ServiceError => error
+      rescue Aws::CostExplorer::Errors::ServiceError, Seahorse::Client::NetworkingError => error
         raise AwsSdkError.new("Unable to determine compute costs for project #{self.name}. #{error if @verbose}") 
       end
       if rerun && compute_cost_log
@@ -312,7 +321,7 @@ class AwsProject < Project
     if !data_out_cost_log || !data_out_amount_log || rerun
       begin
         data_out_figures = @explorer.get_cost_and_usage(data_out_query(date)).results_by_time[0]
-      rescue Aws::CostExplorer::Errors::ServiceError => error
+      rescue Aws::CostExplorer::Errors::ServiceError, Seahorse::Client::NetworkingError => error
         raise AwsSdkError.new("Unable to determine data out figures for project #{self.name}. #{error if @verbose}") 
       end
       data_out_cost = data_out_figures.total["UnblendedCost"][:amount]
@@ -357,7 +366,7 @@ class AwsProject < Project
     if !total_cost_log || rerun
       begin
         daily_cost = @explorer.get_cost_and_usage(all_costs_query(date)).results_by_time[0].total["UnblendedCost"][:amount]
-      rescue Aws::CostExplorer::Errors::ServiceError => error
+      rescue Aws::CostExplorer::Errors::ServiceError, Seahorse::Client::NetworkingError => error
         raise AwsSdkError.new("Unable to determine total costs for project #{self.name}. #{error if @verbose}") 
       end
       if total_cost_log && rerun
@@ -380,7 +389,7 @@ class AwsProject < Project
   def get_cost_per_hour(resource_name, region)
     begin
       result = @pricing_checker.get_products(pricing_query(resource_name, region)).price_list
-    rescue Aws::Pricing::Errors::ServiceError => error
+    rescue Aws::Pricing::Errors::ServiceError, Seahorse::Client::NetworkingError => error
       raise AwsSdkError.new("Unable to get prices for instance type #{resource_name} in region #{region}. #{error if @verbose}") 
     end
     details = JSON.parse(result.first)["terms"]["OnDemand"]
@@ -424,7 +433,7 @@ class AwsProject < Project
     if !logs.any?
       begin
         usage_by_instance_type = @explorer.get_cost_and_usage(compute_instance_type_usage_query(date))
-      rescue Aws::CostExplorer::Errors::ServiceError => error
+      rescue Aws::CostExplorer::Errors::ServiceError, Seahorse::Client::NetworkingError => error
         raise AwsSdkError.new("Unable to determine hours by instance type for project #{self.name}. #{error if @verbose}") 
       end
       usage_by_instance_type.results_by_time[0].groups.each do |group|
@@ -470,12 +479,14 @@ class AwsProject < Project
     today_logs.delete_all if rerun
     if today_logs.count == 0
       regions.reverse.each do |region|
-        @instances_checker = Aws::EC2::Client.new(access_key_id: self.access_key_ident, secret_access_key: self.key, region: region)
-        results = nil
         begin
+          @instances_checker = Aws::EC2::Client.new(access_key_id: self.access_key_ident, secret_access_key: self.key, region: region)
+          results = nil
           results = @instances_checker.describe_instances(project_instances_query)
-        rescue Aws::EC2::Errors::ServiceError => error
+        rescue Aws::EC2::Errors::ServiceError, Seahorse::Client::NetworkingError => error
           raise AwsSdkError.new("Unable to determine AWS instances for project #{self.name} in region #{region}. #{error if @verbose}")
+        rescue Aws::Errors::MissingRegionError => error
+          raise AwsSdkError.new("Unable to determine AWS instances for project #{self.name} due to missing region. #{error if @verbose}")  
         end
         @instances_checker.describe_instances(project_instances_query).reservations.each do |reservation|
           reservation.instances.each do |instance|
@@ -536,7 +547,7 @@ class AwsProject < Project
         while first_query || results&.next_token
           begin
             results = @pricing_checker.get_products(instances_info_query(region, results&.next_token))
-          rescue Aws::Pricing::Errors::ServiceError => error
+          rescue Aws::Pricing::Errors::ServiceError, Aws::Errors::MissingRegionError, Seahorse::Client::NetworkingError => error
             raise AwsSdkError.new("Unable to determine AWS instances in region #{region}. #{error}")
           end
           results.price_list.each do |result|


### PR DESCRIPTION
Aims to resolve #74

- Adds validation when adding or updating projects in `manage_projects.rb`, preventing blank or spaces only values
- Adds error handling for `Aws::Errors::MissingRegionError` (which should never be reached with the above, unless some manual creation/editing of Projects)
- Also adds error handling for `Seahorse::Client::NetworkingError`, caused by AWS reacting badly to blank `access_key_id` or `secret_access_key` (which also should never be reached)
- This prevents such errors from breaking `manage_projects.rb` or reports
- Such errors are checked for when running `validate` in `manage_projects.rb`