### PR TITLE
Short daily report option

### DIFF
--- a/README.md
+++ b/README.md
@@ -105,7 +105,7 @@ Daily reports can be generated using `ruby daily_reports.rb`. If run without any
 
 Weekly reports can similarly be generated using `ruby weekly_reports.rb`. If run without any arguments, this will iterate over all Projects in the database and retrieve data for the month so far, including estimating costs for the rest of the month. The results will be printed to the terminal and posted to the chosen slack channel(s). Weekly reports use the specified date (3 days ago by default) for historical cost data, and will use either use the specified date's instance information, or today's if generating the 'latest' report.
 
-Both of these files also take up to 7 arguments:
+Weekly reports take up to 7 arguments and daily reports up to 8:
 
 1: project name or 'all'\
 2: a specific date or 'latest'. All dates must be in the format YYYY-MM-DD
@@ -114,9 +114,10 @@ The following are optional and unordered (but must be at least the third argumen
 
 3: 'slack' will post the results to the chosen slack channel(s)\
 4: 'text' will print out the results. If no output method is specified (neither 'text' or 'slack'), results will be posted to slack and printed on the terminal\
-5: 'rerun' will ignore cached reports and regenerate them with fresh sdk/ api calls\
-6: 'verbose' will expand any brief Azure errors to include the full HTTP response from the Azure API instead of just the error code.\
-7: 'customer' or 'internal' will show customer facing or true instance names respectively. If not specified, by default daily reports will show true names and weekly reports customer facing names. For weekly reports this argument will not alter a cached report (which is stored as text), so if used for a previously generated weekly report, must also include the argument 'rerun'. Daily reports are stored as their component parts, so these names can be altered without a rerun.
+5: 'rerun' will ignore cached reports and regenerate them with fresh SDK/API calls\
+6: 'verbose' will expand any brief Azure API or AWS SDK errors to include the full error.\
+7: 'customer' or 'internal' will show customer facing or true instance names respectively. If not specified, by default daily reports will show true names and weekly reports customer facing names. For weekly reports this argument will not alter a cached report (which is stored as text), so if used for a previously generated weekly report, must also include the argument 'rerun'. Daily reports are stored as their component parts, so these names can be altered without a rerun.\
+8: 'short' (daily reports only) will ouptut a shortened report, that does not show compute unit costs for compute or data out costs, does not show data out amount and does not show details of instances on the given date.
 
 
 ## Examples
@@ -139,25 +140,29 @@ To get a report for a specific project, with cost data from three days ago, with
 
 `ruby weekly_reports.rb projectName latest slack`
 
-To get a report for a specific project for a specific date, with both slack and text output and using cached data if present
+To get a report for a specific project for a specific date, with both slack and text output and using cached data if present:
 
 `ruby daily_reports.rb projectName 2020-09-20 slack text`
 
 `ruby weekly_reports.rb projectName 2020-09-20 slack text`
 
-To get all projects' reports for a specific day, with only text output and fresh cost and usage queries
+To get all projects' reports for a specific day, with only text output and fresh cost and usage queries:
 
 `ruby daily_reports.rb all 2020-09-20 text rerun`
 
 `ruby weekly_reports.rb all 2020-09-20 text rerun`
 
-To get all projects' daily reports for a specific day, with only text output and customer facing instance names
+To get all projects' daily reports for a specific day, with only text output and customer facing instance names:
 
 `ruby daily_reports.rb all 2020-09-20 text customer`
 
-To get all projects' weekly reports for a specific day, with only text output, true instance names and fresh cost and usage queries
+To get all projects' weekly reports for a specific day, with only text output, true instance names and fresh cost and usage queries:
 
 `ruby weekly_reports.rb all 2020-09-20 text internal rerun `
+
+To get all projects' daily reports for a specific day, with only text output, customer facing instance names, fresh cost and usage queries and with shortened output:
+
+`ruby weekly_reports.rb all 2020-09-20 text internal rerun short`
 
 
 ### Recording Azure Pricing

--- a/daily_reports.rb
+++ b/daily_reports.rb
@@ -30,10 +30,10 @@ require 'date'
 require 'sqlite3'
 require_relative './models/project_factory'
 
-def all_projects(date, slack, text, rerun, verbose, customer_facing)
+def all_projects(date, slack, text, rerun, verbose, customer_facing, short)
   ProjectFactory.new().all_active_projects_as_type.each do |project|
     begin
-      project.daily_report(date, slack, text, rerun, verbose, customer_facing)
+      project.daily_report(date, slack, text, rerun, verbose, customer_facing, short)
     rescue AzureApiError, AwsSdkError => e
       puts "Generation of daily report for project #{project.name} stopped due to error: "
       puts e
@@ -47,6 +47,7 @@ project = nil
 rerun = ARGV.include?("rerun")
 slack = ARGV.include?("slack")
 text = ARGV.include?("text")
+short = ARGV.include?("short")
 customer_facing = ARGV.include?("customer")
 
 if !(slack || text)
@@ -80,11 +81,11 @@ if ARGV[0] && ARGV[0] != "all"
   end
   project = ProjectFactory.new().as_type(project)
   begin
-    project.daily_report(date, slack, text, rerun, verbose, customer_facing)
+    project.daily_report(date, slack, text, rerun, verbose, customer_facing, short)
   rescue AzureApiError, AwsSdkError => e
     puts "Generation of daily report for project #{project.name} stopped due to error: "
     puts e
   end
 else
-  all_projects(date, slack, text, rerun, verbose, customer_facing)
+  all_projects(date, slack, text, rerun, verbose, customer_facing, short)
 end

--- a/models/aws_project.rb
+++ b/models/aws_project.rb
@@ -151,7 +151,7 @@ class AwsProject < Project
       "*Data Out Costs (USD):* #{data_out_cost_log.cost.to_f.ceil(2)}",
       ("*Compute Units (Flat):* #{data_out_cost_log.compute_cost}" if !short),
       ("*Compute Units (Risk):* #{data_out_cost_log.risk_cost}\n" if !short),
-      "*Total Costs(USD):* #{total_cost_log.cost.to_f.ceil(2)}",
+      "*Total Costs (USD):* #{total_cost_log.cost.to_f.ceil(2)}",
       "*Total Compute Units (Flat):* #{total_cost_log.compute_cost}",
       "*Total Compute Units (Risk):* #{total_cost_log.risk_cost}",
       "#{"\n" if !short}*FC Credits:* #{total_cost_log.fc_credits_cost}",

--- a/models/aws_project.rb
+++ b/models/aws_project.rb
@@ -117,7 +117,7 @@ class AwsProject < Project
     valid
   end
 
-  def daily_report(date=(DEFAULT_DATE), slack=true, text=true, rerun=false, verbose=false, customer_facing=false)
+  def daily_report(date=(DEFAULT_DATE), slack=true, text=true, rerun=false, verbose=false, customer_facing=false, short=false)
     @verbose = verbose
     start_date = Date.parse(self.start_date)
     if date < start_date
@@ -145,19 +145,19 @@ class AwsProject < Project
       "#{"*Cached report*" if cached}",
       ":moneybag: Usage for #{(date).to_s} :moneybag:",
       "*Compute Costs (USD):* #{compute_cost_log.cost.to_f.ceil(2)}",
-      "*Compute Units (Flat):* #{compute_cost_log.compute_cost}",
-      "*Compute Units (Risk):* #{compute_cost_log.risk_cost}\n",
-      "*Data Out (GB):* #{data_out_amount_log.amount.to_f.ceil(4)}",
+      ("*Compute Units (Flat):* #{compute_cost_log.compute_cost}" if !short),
+      ("*Compute Units (Risk):* #{compute_cost_log.risk_cost}\n" if !short),
+      ("*Data Out (GB):* #{data_out_amount_log.amount.to_f.ceil(4)}" if !short),
       "*Data Out Costs (USD):* #{data_out_cost_log.cost.to_f.ceil(2)}",
-      "*Compute Units (Flat):* #{data_out_cost_log.compute_cost}",
-      "*Compute Units (Risk):* #{data_out_cost_log.risk_cost}\n",
+      ("*Compute Units (Flat):* #{data_out_cost_log.compute_cost}" if !short),
+      ("*Compute Units (Risk):* #{data_out_cost_log.risk_cost}\n" if !short),
       "*Total Costs(USD):* #{total_cost_log.cost.to_f.ceil(2)}",
       "*Total Compute Units (Flat):* #{total_cost_log.compute_cost}",
-      "*Total Compute Units (Risk):* #{total_cost_log.risk_cost}\n",
-      "*FC Credits:* #{total_cost_log.fc_credits_cost}",
-      "*Compute Instance Usage:* #{overall_usage.strip}",
-      "*Compute Instance Hours:* #{usage_breakdown}"
-    ].join("\n") + "\n"
+      "*Total Compute Units (Risk):* #{total_cost_log.risk_cost}",
+      "#{"\n" if !short}*FC Credits:* #{total_cost_log.fc_credits_cost}",
+      ("*Compute Instance Usage:* #{overall_usage.strip}" if !short),
+      ("*Compute Instance Hours:* #{usage_breakdown}" if !short)
+    ].compact.join("\n") + "\n"
 
     send_slack_message(msg) if slack
 

--- a/models/azure_project.rb
+++ b/models/azure_project.rb
@@ -121,7 +121,7 @@ class AzureProject < Project
     valid
   end
 
-  def daily_report(date=DEFAULT_DATE, slack=true, text=true, rerun=false, verbose=false, customer_facing=false)
+  def daily_report(date=DEFAULT_DATE, slack=true, text=true, rerun=false, verbose=false, customer_facing=false, short=false)
     @verbose = verbose
     refresh_auth_token
     record_instance_logs(rerun) if date == DEFAULT_DATE
@@ -168,18 +168,18 @@ class AzureProject < Project
         "#{"*Cached report*" if cached}",
         ":moneybag: Usage for #{date.to_s} :moneybag:",
         "*Compute Cost (GBP):* #{compute_cost_log.cost.to_f.ceil(2)}",
-        "*Compute Units (Flat):* #{compute_cost_log.compute_cost}",
-        "*Compute Units (Risk):* #{compute_cost_log.risk_cost}\n",
-        "*Data Out (GB):* #{data_out_amount_log.amount.to_f.ceil(4)}",
+        ("*Compute Units (Flat):* #{compute_cost_log.compute_cost}" if !short),
+        ("*Compute Units (Risk):* #{compute_cost_log.risk_cost}\n" if !short),
+        ("*Data Out (GB):* #{data_out_amount_log.amount.to_f.ceil(4)}" if !short),
         "*Data Out Costs (GBP):* #{data_out_cost_log.cost.to_f.ceil(2)}",
-        "*Compute Units (Flat):* #{data_out_cost_log.compute_cost}",
-        "*Compute Units (Risk):* #{data_out_cost_log.risk_cost}\n",
+        ("*Compute Units (Flat):* #{data_out_cost_log.compute_cost}" if !short),
+        ("*Compute Units (Risk):* #{data_out_cost_log.risk_cost}\n" if !short),
         "*Total Cost (GBP):* #{total_cost_log.cost.to_f.ceil(2)}",
         "*Total Compute Units (Flat):* #{total_cost_log.compute_cost}",
-        "*Total Compute Units (Risk):* #{total_cost_log.risk_cost}\n",
-        "*FC Credits:* #{total_cost_log.fc_credits_cost}",
-        "*Compute Instance Usage:* #{overall_usage}"
-      ].join("\n") + "\n"
+        "*Total Compute Units (Risk):* #{total_cost_log.risk_cost}",
+        "#{"\n" if !short}*FC Credits:* #{total_cost_log.fc_credits_cost}",
+        ("*Compute Instance Usage:* #{overall_usage}" if !short)
+      ].compact.join("\n") + "\n"
     send_slack_message(msg) if slack
     
     if text


### PR DESCRIPTION
Aims to resolve #72

- Adds a new optional CLI flag when running `daily_reports.rb`, 'short'
- This reduces the report output (text and/or slack) to just include: currency compute costs, currency data out costs, currency total costs, total compute unit cost, total at risk compute cost and FC credit cost
- Readme updated

AWS: 

![Screenshot from 2020-12-11 10-51-31](https://user-images.githubusercontent.com/59840834/101895061-ece16c80-3b9e-11eb-8dbe-bf6f12c03604.png)
![Screenshot from 2020-12-11 10-51-54](https://user-images.githubusercontent.com/59840834/101895072-ef43c680-3b9e-11eb-8236-8652a5353ec7.png)

Azure:

![Screenshot from 2020-12-11 10-51-40](https://user-images.githubusercontent.com/59840834/101895091-f66ad480-3b9e-11eb-9f7c-3ff8bb990d18.png)
![Screenshot from 2020-12-11 10-52-02](https://user-images.githubusercontent.com/59840834/101895095-f8349800-3b9e-11eb-9f59-3572f20bf173.png)