### PR TITLE
Get aws instance data for all project regions

### DIFF
--- a/get_latest_aws_instance_info.rb
+++ b/get_latest_aws_instance_info.rb
@@ -28,7 +28,7 @@
 require_relative './models/aws_project.rb'
 
 # Need AWS credentials to get instance list, so use a project in database.
-project = AwsProject.where(host: 'aws').first
+project = AwsProject.first
 if !project
   puts "No AWS projects in database to retrieve instances details"
 else

--- a/get_latest_azure_instance_sizes.rb
+++ b/get_latest_azure_instance_sizes.rb
@@ -28,7 +28,7 @@
 require_relative './models/azure_project.rb'
 
 # Need Azure credentials to get instance list, so use a project in database.
-project = AzureProject.where(host: 'azure').first
+project = AzureProject.first
 if !project
   puts "No Azure projects in database to retrieve price list"
 else

--- a/get_latest_azure_prices.rb
+++ b/get_latest_azure_prices.rb
@@ -29,7 +29,7 @@ require_relative './models/azure_project.rb'
 
 # Need Azure credentials to get price list, so use a project in database.
 # Assumes all projects are registered in the UK, using GBP and a 'pay as you go' pricing model.
-project = AzureProject.where(host: 'azure').first
+project = AzureProject.first
 if !project
   puts "No Azure projects in database to retrieve price list"
 else

--- a/models/aws_project.rb
+++ b/models/aws_project.rb
@@ -512,7 +512,7 @@ class AwsProject < Project
   end
 
   def get_aws_instance_info
-    regions = InstanceLog.where(host: "AWS").select(:region).distinct.pluck(:region).sort
+    regions = AwsProject.where(host: "aws").map { |project| project.regions }.flatten.uniq.sort
 
     timestamp = begin
       Date.parse(File.open('aws_instance_details.txt').first) 

--- a/models/aws_project.rb
+++ b/models/aws_project.rb
@@ -36,6 +36,8 @@ class AwsProject < Project
   @@region_mappings = {}
   after_initialize :add_sdk_objects
 
+  default_scope { where(host: "aws") }
+
   def access_key_ident
     @metadata['access_key_ident']
   end
@@ -512,7 +514,7 @@ class AwsProject < Project
   end
 
   def get_aws_instance_info
-    regions = AwsProject.where(host: "aws").map { |project| project.regions }.flatten.uniq | ["eu-west-2"]
+    regions = AwsProject.all.map(&:regions).flatten.uniq | ["eu-west-2"]
     regions.sort!
 
     timestamp = begin

--- a/models/aws_project.rb
+++ b/models/aws_project.rb
@@ -512,7 +512,8 @@ class AwsProject < Project
   end
 
   def get_aws_instance_info
-    regions = AwsProject.where(host: "aws").map { |project| project.regions }.flatten.uniq.sort
+    regions = AwsProject.where(host: "aws").map { |project| project.regions }.flatten.uniq | ["eu-west-2"]
+    regions.sort!
 
     timestamp = begin
       Date.parse(File.open('aws_instance_details.txt').first) 

--- a/models/azure_project.rb
+++ b/models/azure_project.rb
@@ -37,6 +37,8 @@ class AzureProject < Project
   after_initialize :construct_metadata
   after_initialize :update_region_mappings
 
+  default_scope { where(host: "azure") }
+
   def tenant_id
     @metadata['tenant_id']
   end


### PR DESCRIPTION
Currently we only record AWS instance details & prices for regions where instances have been recorded. However, in the `cloud-cost-visualiser` there may be projects with regions where there have never been any instance logs.

This PR therefore ensures that AWS instance data is retrieved for all AWS projects' regions. It also ensures this includes the region `eu-west-2`, which will be required for https://github.com/openflighthpc/cloud-cost-visualiser/issues/38