### PR TITLE
Record historic data within date range

### DIFF
--- a/README.md
+++ b/README.md
@@ -187,6 +187,8 @@ Historic gaps can also be filled when adding a project using `manage_projects.rb
 
 For AWS projects this retrieval and recording is a quick process, even with a large date range (300+ days). However, due to limitations in possible queries to Azure APIs and their slow responses, this can take 5+ minutes per 1 month of data for Azure Projects.
 
+Please note that compute costs are only available for dates after compute tags have been added to resources. For Azure projects, historic compute costs will be available only for instances that have previously been identified and recorded as compute instances in instance logs.
+
 # Contributing
 
 Fork the project. Make your feature addition or bug fix. Send a pull

--- a/README.md
+++ b/README.md
@@ -175,6 +175,18 @@ You can also run `ruby get_latest_azure_prices.rb`, which will use an existing A
 
 The application also includes initial versions of the files `aws_instance_details.txt` and `azure_instance_sizes.txt`. These are not required for this application, but are used by the associated openflight `cloud-cost-visualiser` project, with the files generated here as they require a valid AWS / Azure project for retrieving the data. These can be updated by runing `ruby get_latest_aws_instance_info` and `ruby get_latest_azure_instance_sizes.rb` respectively.
 
+### Recording historic cost logs
+
+If a project has significant gaps in its cost and usage logs, for example due to only recently being added to this application, two helpers are provided to fill these gaps without the need for manually running daily reports for each missing day.
+
+Firstly, `record_logs.rb` can be run, with three required arguments and one optional argument. These are, in order: the project name, start date, end date and rerun (optional). This will query the relevant AWS SDKs / Azure APIs and record cost and usage logs for all days in that date range (inclusive). For example `ruby record_logs.rb project1 2020-01-01 2020-09-30` will record logs for the project named project1 for all days between and including 1st January 2020 to 30th September.
+
+If the 4th, optional argument `rerun` is not included, this will ignore any dates which already have logs recorded. If it is included, any existing logs will be overwritten with newly retrieved data.
+
+Historic gaps can also be filled when adding a project using `manage_projects.rb`. Here, if the project has a start date in the past, after the project is created the user is asked if they want to retrieve historic data. Entering `y` will carry out the same process as in `record_logs.rb`, for all dates from the project start date to 3 days ago (the latest date cost data is available).
+
+For AWS projects this retrieval and recording is a quick process, even with a large date range (300+ days). However, due to limitations in possible queries to Azure APIs and their slow responses, this can take 5+ minutes per 1 month of data for Azure Projects.
+
 # Contributing
 
 Fork the project. Make your feature addition or bug fix. Send a pull

--- a/daily_reports.rb
+++ b/daily_reports.rb
@@ -25,9 +25,7 @@
 # https://github.com/openflighthpc/cloud-cost-reporter
 #==============================================================================
 
-require 'json'
 require 'date'
-require 'sqlite3'
 require_relative './models/project_factory'
 
 def all_projects(date, slack, text, rerun, verbose, customer_facing, short)

--- a/manage_projects.rb
+++ b/manage_projects.rb
@@ -454,6 +454,7 @@ def add_project
         stop = true
         valid = true
       elsif response == "y"
+        "Recording logs"
         valid = true
         project = ProjectFactory.new().as_type(project)
         begin

--- a/manage_projects.rb
+++ b/manage_projects.rb
@@ -429,24 +429,44 @@ def add_project
   Budget.create(project_id: project.id, amount: budget, effective_at: project.start_date, timestamp: Time.now)
   puts "Project #{project.name} created"
   
-  stop = false
-  while !stop
+  credentials = nil
+  valid = false
+  while !valid
+    print "Validate credentials (y/n)? "
+    response = gets.chomp.downcase
+    if response == "n"
+      valid = true
+    elsif response == "y"
+      valid = true
+      credentials = validate_credentials(project)
+    else
+      puts "Invalid response. Please try again"
+    end
+  end
+
+  if credentials != false && Date.parse(project.start_date) < Project::DEFAULT_DATE
     valid = false
     while !valid
-      print "Validate credentials (y/n)? "
+      print "Project start date is in the past. Would you like to retrieve and record historic costs (y/n)? "
+      print "This may take a long time (5+ mins per month of data). " if project.host == "azure"
       response = gets.chomp.downcase
       if response == "n"
         stop = true
         valid = true
       elsif response == "y"
         valid = true
+        project = ProjectFactory.new().as_type(project)
+        begin
+          project.record_logs_for_range(Date.parse(project.start_date), Project::DEFAULT_DATE - 1.day)
+        rescue AzureApiError, AwsSdkError => e
+          puts "Generation of logs for project #{project.name} stopped due to error: "
+          puts e
+          return
+        end
+        puts "Logs recorded."
       else
         puts "Invalid response. Please try again"
       end
-    end
-    if !stop
-      stop = true
-      validate_credentials(project)
     end
   end
 end
@@ -454,7 +474,6 @@ end
 def validate_credentials(project)
   project = @factory.as_type(project)
   project.validate_credentials
-  puts
 end
 
 def add_budget(project)

--- a/models/aws_project.rb
+++ b/models/aws_project.rb
@@ -96,7 +96,7 @@ class AwsProject < Project
       @pricing_checker = Aws::Pricing::Client.new(access_key_id: self.access_key_ident, secret_access_key: self.key)
     rescue Aws::Errors::MissingRegionError => error
       puts "Unable to create AWS SDK objects due to missing region: #{error}"
-      return
+      return false
     end
 
     begin

--- a/models/aws_project.rb
+++ b/models/aws_project.rb
@@ -506,7 +506,7 @@ class AwsProject < Project
 
   def get_usage_hours_by_instance_type(start_date=DEFAULT_DATE, rerun=false, customer_facing=false)
     logs = self.usage_logs.where(unit: "hours").where(scope: "compute").where(start_date: start_date).where(end_date: start_date + 1.day)
-    logs = get_usage_hours(start_date, start_date + 1.day, rerun) if !logs || rerun
+    logs = get_usage_hours(start_date, start_date + 1.day, rerun) if !logs.any? || rerun
     usage_breakdown = "\n\t\t\t\t"
     compute_other = []
     
@@ -572,8 +572,8 @@ class AwsProject < Project
     @explorer.get_cost_and_usage(data_out_query(date))
   end
 
-  def record_cost_data_for_range(start_date, end_date, rerun=false)
-    # AWS SDK does not include end date, so much increment by one day
+  def record_logs_for_range(start_date, end_date, rerun=false)
+    # AWS SDK does not include end date, so must increment by one day
     end_date = end_date + 1.day
     get_compute_costs(start_date, end_date, rerun)
     get_data_out_figures(start_date, end_date, rerun)

--- a/models/azure_project.rb
+++ b/models/azure_project.rb
@@ -494,8 +494,6 @@ class AzureProject < Project
         timeout: DEFAULT_TIMEOUT
       )
 
-      puts response
-
       if response.success?
         vms = response['value']
         vms.select { |vm| vm.key?('tags') && vm['tags']['type'] == 'compute' && self.resource_groups.include?(vm['id'].split('/')[4].downcase) }

--- a/models/azure_project.rb
+++ b/models/azure_project.rb
@@ -465,7 +465,7 @@ class AzureProject < Project
     return data_out_cost_log, data_out_amount_log
   end
 
-  def record_cost_data_for_range(start_date, end_date, rerun=false)
+  def record_logs_for_range(start_date, end_date, rerun=false)
     update_bearer_token
     (start_date..end_date).to_a.each do |date|
       logs = self.cost_logs.where(date: date)

--- a/models/azure_project.rb
+++ b/models/azure_project.rb
@@ -466,10 +466,15 @@ class AzureProject < Project
   end
 
   def record_cost_data_for_range(start_date, end_date, rerun=false)
-    refresh_auth_token
+    update_bearer_token
     (start_date..end_date).to_a.each do |date|
-      response = api_query_cost(date)
-      get_total_costs(response, date, rerun)
+      logs = self.cost_logs.where(date: date)
+      if !logs.any? || rerun
+        response = api_query_cost(date)
+        get_total_costs(response, date, rerun)
+        get_compute_costs(response, date, rerun)
+        get_data_out_figures(response, date, rerun)
+      end
     end
   end
 

--- a/models/azure_project.rb
+++ b/models/azure_project.rb
@@ -467,6 +467,7 @@ class AzureProject < Project
 
   def record_logs_for_range(start_date, end_date, rerun=false)
     update_bearer_token
+    record_instance_logs # need some instance logs in order to determine compute costs
     (start_date..end_date).to_a.each do |date|
       logs = self.cost_logs.where(date: date)
       if !logs.any? || rerun
@@ -492,6 +493,8 @@ class AzureProject < Project
         headers: { 'Authorization': "Bearer #{bearer_token}" },
         timeout: DEFAULT_TIMEOUT
       )
+
+      puts response
 
       if response.success?
         vms = response['value']

--- a/models/azure_project.rb
+++ b/models/azure_project.rb
@@ -137,29 +137,7 @@ class AzureProject < Project
 
     if rerun || !(total_cost_log && data_out_cost_log && data_out_amount_log && compute_cost_log)
       response = api_query_cost(date)
-      # the query has multiple values that sound useful (effectivePrice, cost, 
-      # quantity, unitPrice). 'cost' is the value that is used on the Azure Portal
-      # Cost Analysis page (under 'Actual Cost') for the period selected.
-      daily_cost = begin
-                     response.map { |c| c['properties']['cost'] }.reduce(:+)
-                   rescue NoMethodError
-                     0.0
-                   end
-
-      if rerun && total_cost_log
-        total_cost_log.assign_attributes(cost: daily_cost, timestamp: Time.now.to_s)
-        total_cost_log.save!
-      else
-        total_cost_log = CostLog.create(
-          project_id: id,
-          cost: daily_cost,
-          currency: 'GBP',
-          scope: 'total',
-          date: date.to_s,
-          timestamp: Time.now.to_s
-        )
-      end
-
+      total_cost_log = get_total_costs(response, date, rerun)
       data_out_cost_log, data_out_amount_log = get_data_out_figures(response, date, rerun)
       compute_cost_log = get_compute_costs(response, date, rerun)
     end
@@ -380,6 +358,35 @@ class AzureProject < Project
     overall_usage == "" ? "None recorded" : overall_usage.strip
   end
 
+  def get_total_costs(cost_entries, date, rerun)
+    total_cost_log = self.cost_logs.find_by(date: date.to_s, scope: "total")
+    if !total_cost_log || rerun
+      # the query has multiple values that sound useful (effectivePrice, cost, 
+      # quantity, unitPrice). 'cost' is the value that is used on the Azure Portal
+      # Cost Analysis page (under 'Actual Cost') for the period selected.
+      daily_cost = begin
+                    cost_entries.map { |c| c['properties']['cost'] }.reduce(:+)
+                  rescue NoMethodError
+                    0.0
+                  end
+
+      if rerun && total_cost_log
+        total_cost_log.assign_attributes(cost: daily_cost, timestamp: Time.now.to_s)
+        total_cost_log.save!
+      else
+        total_cost_log = CostLog.create(
+          project_id: id,
+          cost: daily_cost,
+          currency: 'GBP',
+          scope: 'total',
+          date: date.to_s,
+          timestamp: Time.now.to_s
+        )
+      end
+    end
+    total_cost_log
+  end
+
   def get_compute_costs(cost_entries, date, rerun)
     compute_cost_log = self.cost_logs.find_by(date: date.to_s, scope: "compute")
 
@@ -456,6 +463,14 @@ class AzureProject < Project
       end
     end
     return data_out_cost_log, data_out_amount_log
+  end
+
+  def record_cost_data_for_range(start_date, end_date, rerun=false)
+    refresh_auth_token
+    (start_date..end_date).to_a.each do |date|
+      response = api_query_cost(date)
+      get_total_costs(response, date, rerun)
+    end
   end
 
   def api_query_compute_nodes

--- a/record_logs.rb
+++ b/record_logs.rb
@@ -1,0 +1,80 @@
+#==============================================================================
+# Copyright (C) 2020-present Alces Flight Ltd.
+#
+# This file is part of cloud-cost-reporter.
+#
+# This program and the accompanying materials are made available under
+# the terms of the Eclipse Public License 2.0 which is available at
+# <https://www.eclipse.org/legal/epl-2.0>, or alternative license
+# terms made available by Alces Flight Ltd - please direct inquiries
+# about licensing to licensing@alces-flight.com.
+#
+# cloud-cost-reporter is distributed in the hope that it will be useful, but
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, EITHER EXPRESS OR
+# IMPLIED INCLUDING, WITHOUT LIMITATION, ANY WARRANTIES OR CONDITIONS
+# OF TITLE, NON-INFRINGEMENT, MERCHANTABILITY OR FITNESS FOR A
+# PARTICULAR PURPOSE. See the Eclipse Public License 2.0 for more
+# details.
+#
+# You should have received a copy of the Eclipse Public License 2.0
+# along with cloud-cost-reporter. If not, see:
+#
+#  https://opensource.org/licenses/EPL-2.0
+#
+# For more information on cloud-cost-reporter, please visit:
+# https://github.com/openflighthpc/cloud-cost-reporter
+#==============================================================================
+
+require 'date'
+require_relative './models/project_factory'
+
+project = nil
+start_date = nil
+end_date = nil
+rerun = ARGV.include?("rerun")
+project = Project.find_by(name: ARGV[0])
+if project == nil
+  puts "Project with that name not found"
+  return
+end
+
+valid = begin
+  Date.parse(ARGV[1])
+rescue ArgumentError
+  false
+end
+if !valid
+  puts "Provided start date invalid"
+  return
+end
+start_date = valid
+
+valid = begin
+  Date.parse(ARGV[2])
+rescue ArgumentError
+  false
+end
+if !valid
+  puts "Provided end date invalid"
+  return
+end
+end_date = valid
+
+if end_date <= start_date
+  puts "End date must be after start date"
+  return
+end
+
+if end_date > Project::DEFAULT_DATE
+  puts "End date must be earlier than #{Project::DEFAULT_DATE}"
+  return
+end
+
+begin
+  project = ProjectFactory.new().as_type(project)
+  project.record_logs_for_range(start_date, end_date, rerun)
+rescue AzureApiError, AwsSdkError => e
+  puts "Generation of logs for project #{project.name} stopped due to error: "
+  puts e
+  return
+end

--- a/record_logs.rb
+++ b/record_logs.rb
@@ -70,6 +70,8 @@ if end_date > Project::DEFAULT_DATE
   return
 end
 
+puts "Recording logs."
+puts "This may take some time (5+ mins per month of data). " if project.host == "azure"
 begin
   project = ProjectFactory.new().as_type(project)
   project.record_logs_for_range(start_date, end_date, rerun)
@@ -78,3 +80,4 @@ rescue AzureApiError, AwsSdkError => e
   puts e
   return
 end
+puts "Logs recorded."

--- a/weekly_reports.rb
+++ b/weekly_reports.rb
@@ -25,9 +25,7 @@
 # https://github.com/openflighthpc/cloud-cost-reporter
 #==============================================================================
 
-require 'json'
 require 'date'
-require 'sqlite3'
 require_relative './models/project_factory'
 
 def all_projects(date, slack, text, rerun, verbose, customer_facing)


### PR DESCRIPTION
Aims to resolve #81

**Record Logs**
- Adds a new script `record_logs.rb`, for retrieving and recording cost & usage data for multiple dates, without generating any reports
- This takes 3 required arguments: project name, start date and end date
- Will retrieve data and record logs for all dates (inclusive) between those two dates
- Also can take a 4th, optional argument, `rerun`. If not included, dates which already have logs will be ignored. If `rerun` is included, any existing logs will be overwritten

**Manage Projects**
- Adds a new option after creating a new project in `mange_projects`. Here, if the newly created project has a start date in the past, user will be asked if they want to record historic data
- If they answer 'y', this will retrieve and record logs for all dates from the project start date to 3 days ago (the latest date cost data is available)

For AWS projects this is fast, even with large date ranges (300+ days). However, Azure APIs are very limited and slow in their responses, so this can take 5+mins per 1 month of data for Azure projects.

**Implementation Detail**
- Adds new method `record_logs_for_range` for both `AwsProject` and `AzureProject`
- For AWS projects, the methods for retrieving compute, total, data out and usage logs are updated to now take a start date and an end date
- These methods are still used when generating the daily reports
- For each cost/ usage type, an individual SDK query is made for the entire date range, as the AWS SDK can give responses grouped by day
- This is therefore very efficient in terms of SDK queries
- For Azure Projects, their APIs do not allow for grouping by day (e.g. if give a date range, each cost type is the total cost for that entire period)
- Therefore 1 API call must be made for each day in the range
- This is therefore slow & inefficient, but does not seem to be avoidable given the limitations of Azure's APIs (unless you can find a way of getting costs by day? As far as I can see, no such method is included in their documentation, but this is also very limited).

**Note:** As this involves a change to how the daily reports are being generated and their are multiple possible conditions (no logs, some logs, rerun, etc.) this would benefit from some further in depth testing.
