### PR TITLE
show project name in messages

### DIFF
--- a/models/aws_project.rb
+++ b/models/aws_project.rb
@@ -154,7 +154,7 @@ class AwsProject < Project
     msg = [
       "#{date_warning if date_warning}",
       "#{"*Cached report*" if cached}",
-      ":moneybag: Usage for #{(date).to_s} :moneybag:",
+      ":moneybag: Usage for *#{self.name}* on #{date.to_s} :moneybag:",
       "*Compute Costs (USD):* #{compute_cost_log.cost.to_f.ceil(2)}",
       ("*Compute Units (Flat):* #{compute_cost_log.compute_cost}" if !short),
       ("*Compute Units (Risk):* #{compute_cost_log.risk_cost}\n" if !short),
@@ -173,7 +173,6 @@ class AwsProject < Project
     send_slack_message(msg) if slack
 
     if text
-      puts "\nProject: #{self.name}"
       puts msg.gsub(":moneybag:", "").gsub("*", "").gsub("\t", "")
       puts "_" * 50
     end

--- a/models/azure_project.rb
+++ b/models/azure_project.rb
@@ -168,7 +168,7 @@ class AzureProject < Project
 
     msg = [
         "#{"*Cached report*" if cached}",
-        ":moneybag: Usage for #{date.to_s} :moneybag:",
+        ":moneybag: Usage for *#{self.name}* on #{date.to_s} :moneybag:",
         "*Compute Cost (GBP):* #{compute_cost_log.cost.to_f.ceil(2)}",
         ("*Compute Units (Flat):* #{compute_cost_log.compute_cost}" if !short),
         ("*Compute Units (Risk):* #{compute_cost_log.risk_cost}\n" if !short),
@@ -176,7 +176,7 @@ class AzureProject < Project
         "*Data Out Costs (GBP):* #{data_out_cost_log.cost.to_f.ceil(2)}",
         ("*Compute Units (Flat):* #{data_out_cost_log.compute_cost}" if !short),
         ("*Compute Units (Risk):* #{data_out_cost_log.risk_cost}\n" if !short),
-        "*Total Cost (GBP):* #{total_cost_log.cost.to_f.ceil(2)}",
+        "*Total Costs (GBP):* #{total_cost_log.cost.to_f.ceil(2)}",
         "*Total Compute Units (Flat):* #{total_cost_log.compute_cost}",
         "*Total Compute Units (Risk):* #{total_cost_log.risk_cost}",
         "#{"\n" if !short}*FC Credits:* #{total_cost_log.fc_credits_cost}",
@@ -185,7 +185,6 @@ class AzureProject < Project
     send_slack_message(msg) if slack
     
     if text
-      puts "\nProject: #{self.name}\n"
       puts msg.gsub(":moneybag:", "").gsub("*", "")
       puts "_" * 50
     end


### PR DESCRIPTION
Aims to resolve #82

- Includes project name in title of output message (slack and text)
- For both AWS and Azure projects
- For both short and long versions

![Screenshot from 2021-01-04 10-14-57](https://user-images.githubusercontent.com/59840834/103524835-217ed600-4e76-11eb-94be-774ca7fa105c.png)

![Screenshot from 2021-01-04 10-15-34](https://user-images.githubusercontent.com/59840834/103524828-1fb51280-4e76-11eb-8ebd-6efcbca8cb8f.png)

