### PR TITLE
Send slack message when an API error occurs

### DIFF
--- a/daily_reports.rb
+++ b/daily_reports.rb
@@ -33,9 +33,14 @@ def all_projects(date, slack, text, rerun, verbose, customer_facing, short)
     begin
       project.daily_report(date, slack, text, rerun, verbose, customer_facing, short)
     rescue AzureApiError, AwsSdkError => e
-      puts "Generation of daily report for project #{project.name} stopped due to error: "
-      puts e
-      puts "_" * 50
+      error = <<~MSG
+      Generation of daily report for project *#{project.name}* stopped due to error:
+      #{e}
+      #{"_" * 50}
+      MSG
+
+      project.send_slack_message(error)
+      puts error.gsub("*", "")
     end
   end
 end

--- a/daily_reports.rb
+++ b/daily_reports.rb
@@ -39,7 +39,7 @@ def all_projects(date, slack, text, rerun, verbose, customer_facing, short)
       #{"_" * 50}
       MSG
 
-      project.send_slack_message(error)
+      project.send_slack_message(error) if slack
       puts error.gsub("*", "")
     end
   end

--- a/daily_reports.rb
+++ b/daily_reports.rb
@@ -36,10 +36,10 @@ def all_projects(date, slack, text, rerun, verbose, customer_facing, short)
       error = <<~MSG
       Generation of daily report for project *#{project.name}* stopped due to error:
       #{e}
-      #{"_" * 50}
       MSG
 
       project.send_slack_message(error) if slack
+      error << "\n#{"_" * 50}"
       puts error.gsub("*", "")
     end
   end

--- a/weekly_reports.rb
+++ b/weekly_reports.rb
@@ -36,10 +36,10 @@ def all_projects(date, slack, text, rerun, verbose, customer_facing)
       error = <<~MSG
       Generation of weekly report for project #{project.name} stopped due to error:
       #{e}
-      #{"_" * 50}
       MSG
 
       project.send_slack_message(error) if slack
+      error << "\n#{"_" * 50}"
       puts error.gsub("*", "")
     end
   end

--- a/weekly_reports.rb
+++ b/weekly_reports.rb
@@ -33,9 +33,14 @@ def all_projects(date, slack, text, rerun, verbose, customer_facing)
     begin
       project.weekly_report(date, slack, text, rerun, verbose, customer_facing)
     rescue AzureApiError, AwsSdkError => e
-      puts "Generation of weekly report for project #{project.name} stopped due to error: "
-      puts e
-      puts "_" * 50
+      error = <<~MSG
+      Generation of weekly report for project #{project.name} stopped due to error:
+      #{e}
+      #{"_" * 50}
+      MSG
+
+      project.send_slack_message(error)
+      puts error.gsub("*", "")
     end
   end
 end

--- a/weekly_reports.rb
+++ b/weekly_reports.rb
@@ -39,7 +39,7 @@ def all_projects(date, slack, text, rerun, verbose, customer_facing)
       #{"_" * 50}
       MSG
 
-      project.send_slack_message(error)
+      project.send_slack_message(error) if slack
       puts error.gsub("*", "")
     end
   end


### PR DESCRIPTION
As title. Similar messages were not added for the `manage_projects.rb` or `record_logs.rb` scripts as they do not post anything else to Slack.

Resolves #86 when merged.