### PR TITLE
Record compute group costs (Azure)

### DIFF
--- a/README.md
+++ b/README.md
@@ -37,7 +37,7 @@ For AWS projects you also need to supply your 12 digit `AWS Account ID`, which c
 
 ### Azure
 
-In this application, Azure projects are assumed to be confined to a single Azure resource group (to be specified at project creation). In addition, it is required that compute nodes be given the `"type" => "compute"` tag on the Azure platform and core infrastructure given the `"type" => "core"` tag.
+In this application, Azure projects are assumed to be confined to a single Azure resource group (to be specified at project creation). In addition, it is required that compute nodes be given the `"type" => "compute"` tag on the Azure platform and core infrastructure given the `"type" => "core"` tag. If compute groups are being used, compute nodes must also be identified with the tag `"compute_group" => "groupname"`.
 
 The point at which tags are added does not affect the data pulled from the Azure API. As long as the resources that you want to analyse have the tag, the detail objects associated with that resource will be queried.
 

--- a/models/azure_project.rb
+++ b/models/azure_project.rb
@@ -395,7 +395,6 @@ class AzureProject < Project
     compute_cost_log = self.cost_logs.find_by(date: date.to_s, scope: "compute")
 
     if !compute_cost_log || rerun
-
       compute_costs = cost_entries.select do |cost|
         historic_compute_nodes(date).any? do |node| 
           node.instance_name == cost['properties']['resourceName'] &&

--- a/models/azure_project.rb
+++ b/models/azure_project.rb
@@ -415,22 +415,17 @@ class AzureProject < Project
           cost_breakdown[group] += value
         end
       end
-
-      if rerun && compute_cost_log
-        cost_breakdown.each do |key, value|
-          scope = key == :total ? "compute" : key
-          log = self.cost_logs.find_by(date: date.to_s, scope: scope)
-          if log
-            log.assign_attributes(cost: cost_breakdown[key], timestamp: Time.now.to_s)
-            log.save!
-          end
-        end
-      else
-        cost_breakdown.each do |key, value|
-          scope = key == :total ? "compute" : key
+      
+      cost_breakdown.each do |key, value|
+        scope = key == :total ? "compute" : key
+        log = self.cost_logs.find_by(date: date.to_s, scope: scope)
+        if log && rerun
+          log.assign_attributes(cost: cost_breakdown[key], timestamp: Time.now.to_s)
+          log.save!
+        elsif !log
           log = CostLog.create(
             project_id: id,
-            cost: cost_breakdown[key],
+            cost: value,
             currency: 'GBP',
             scope: scope,
             date: date.to_s,

--- a/models/azure_project.rb
+++ b/models/azure_project.rb
@@ -67,10 +67,6 @@ class AzureProject < Project
     @today_compute_nodes ||= api_query_compute_nodes
   end
 
-  def historic_compute_nodes(date)
-    self.instance_logs.where("timestamp LIKE ?", "%#{date}%").where(compute: 1)
-  end
-
   def resource_groups
     @metadata['resource_groups']
   end
@@ -396,15 +392,12 @@ class AzureProject < Project
 
     if !compute_cost_log || rerun
       compute_costs = cost_entries.select do |cost|
-        historic_compute_nodes(date).any? do |node| 
-          node.instance_name == cost['properties']['resourceName'] &&
-          !(cost['properties']["additionalInfo"] &&
-          JSON.parse(cost["properties"]["additionalInfo"])["UsageResourceKind"]&.include?("DataTrOut"))
-        end
+        cost["tags"] && cost["tags"]["type"] == "compute" &&
+        cost['properties']["additionalInfo"] &&
+        JSON.parse(cost["properties"]["additionalInfo"])["UsageType"] == "ComputeHR"
       end
 
       cost_breakdown = {total: 0.0}
-      compute_costs = cost_entries.select { |cd| historic_compute_nodes(date).any? { |node| node.instance_name == cd['properties']['resourceName'] } }
       compute_costs.each do |cost|
         value = cost['properties']['cost']
         group = cost["tags"] ? cost["tags"]["compute_group"] : nil


### PR DESCRIPTION
Aims to resolve #89

- For Azure projects only, records costs for each 'compute group'
- Compute groups are defined by the tag `"compute_group" => "groupname"`
- Resources must also have the `"type" => "compute"` tag
-  Does not include data out costs
- Costs for each compute group are recorded in their own `CostLog` with the `scope` of their 'groupname', for use by the `cloud-cost-visualiser`. They are not added to the reporter text/slack output
- Also updates how compute costs are identified, namely by using the compute tag, rather than comparing to instance logs

<img src="https://user-images.githubusercontent.com/59840834/104192819-45628e80-5417-11eb-92b8-9d21b1491902.png" height="200px">
