### PR TITLE
add compute group to azure instance logs

### DIFF
--- a/db/add_compute_group.rb
+++ b/db/add_compute_group.rb
@@ -1,0 +1,33 @@
+#==============================================================================
+# Copyright (C) 2020-present Alces Flight Ltd.
+#
+# This file is part of cloud-cost-reporter.
+#
+# This program and the accompanying materials are made available under
+# the terms of the Eclipse Public License 2.0 which is available at
+# <https://www.eclipse.org/legal/epl-2.0>, or alternative license
+# terms made available by Alces Flight Ltd - please direct inquiries
+# about licensing to licensing@alces-flight.com.
+#
+# cloud-cost-reporter is distributed in the hope that it will be useful, but
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, EITHER EXPRESS OR
+# IMPLIED INCLUDING, WITHOUT LIMITATION, ANY WARRANTIES OR CONDITIONS
+# OF TITLE, NON-INFRINGEMENT, MERCHANTABILITY OR FITNESS FOR A
+# PARTICULAR PURPOSE. See the Eclipse Public License 2.0 for more
+# details.
+#
+# You should have received a copy of the Eclipse Public License 2.0
+# along with cloud-cost-reporter. If not, see:
+#
+#  https://opensource.org/licenses/EPL-2.0
+#
+# For more information on cloud-cost-reporter, please visit:
+# https://github.com/openflighthpc/cloud-cost-reporter
+#==============================================================================
+
+require 'sqlite3'
+
+db = SQLite3::Database.open 'db/cost_tracker.sqlite3'
+
+db.execute "ALTER TABLE instance_logs
+ADD COLUMN compute_group TEXT;"

--- a/db/setup.rb
+++ b/db/setup.rb
@@ -55,6 +55,7 @@ db.execute "CREATE TABLE IF NOT EXISTS instance_logs(
   instance_type TEXT,
   region TEXT,
   compute INTEGER,
+  compute_group TEXT,
   status TEXT,
   timestamp TEXT
 )"

--- a/models/azure_project.rb
+++ b/models/azure_project.rb
@@ -315,12 +315,14 @@ class AzureProject < Project
                 end
         type = cnode['properties']['hardwareProfile']['vmSize']
         compute = cnode.key?('tags') && cnode['tags']['type'] == 'compute'
+        compute_group = cnode.key?('tags') ? cnode['tags']['compute_group'] : nil
         InstanceLog.create(
           instance_id: node['id'],
           project_id: id,
           instance_type: type,
           instance_name: name,
           compute: compute ? 1 : 0,
+          compute_group: compute_group,
           status: node['properties']['availabilityState'],
           host: 'Azure',
           region: region,


### PR DESCRIPTION
Aims to resolve #94

- Adds a new field `compute_group` for `InstanceLogs`
- Added to `db/setup.rb` for new databases and the script `db/add_compute_group.rb` created for adding this column to an existing database
- This is currently only set in `InstanceLogs` recorded by Azure projects, with the value of the instance's `compute_group` tag
- Once a tag is added, the compute group can be read without any significant delay (e.g. if a compute group added to a VM and the daily report generated a few minutes later, the group will be read & recorded)
- `Compute group` is not used by this application, but will be used by the `cloud-cost-visualiser`

![Screenshot from 2021-01-07 17-09-37](https://user-images.githubusercontent.com/59840834/103922147-42ac2480-510b-11eb-9c71-a706b3d22502.png)