### PR TITLE
Remove aws account id filter

### DIFF
--- a/README.md
+++ b/README.md
@@ -23,17 +23,15 @@ ruby db/add_instance_mappings.rb
 
 ### AWS
 
-On AWS, projects can be tracked on an account or project tag level. For tracking by project tag, ensure that all desired resources are given a tag with the key `project` and a value of what you have named the project. 
+On AWS, projects can be tracked on an account or project tag level. For tracking by project tag, ensure that all desired resources are given a tag with the key `project` and a value of what you have named the project. Account level will include any subaccounts.
 
-These tags should be added at the point a resource is created. If adding tags to instances in the AWS online console, these tags will also be applied to their associated storage. However, if creating instances via CloudFormation, these must be tagged explictly (see https://aws.amazon.com/premiumsupport/knowledge-center/cloudformation-instance-tag-root-volume/). It is recommended that these project tags are added even if the intention is to track by account number, as this will allow for greater flexibility and accuracy if a second project is later added to the same account.
+These tags should be added at the point a resource is created. If adding tags to instances in the AWS online console, these tags will also be applied to their associated storage. However, if creating instances via CloudFormation, these must be tagged explictly (see https://aws.amazon.com/premiumsupport/knowledge-center/cloudformation-instance-tag-root-volume/). It is recommended that these project tags are added even if the intention is to track by account, as this will allow for greater flexibility and accuracy if a second project is later added to the same account.
 
 This application includes in its breakdown details of instances specifically used as compute nodes. For this to be measured accurately, the appropriate instances should have a tag added with the key `compute` and the value `true`. Again, these should be added at the point of creation.
 
 The project and compute tags must also be activated in the Billing console (see https://docs.aws.amazon.com/awsaccountbilling/latest/aboutv2/activating-tags.html). It may take up to 24 hours for new tags to appear in this console.
 
 This application makes use of a number of AWS sdks, which require a valid `Access Key ID` and `Secret Access Key`. This should relate to a user with access to: Billing and Cost Management, Cost Explorer API, EC2 API and Pricing API.
-
-For AWS projects you also need to supply your 12 digit `AWS Account ID`, which can be found on the AWS console under 'My Security Credentials' (see https://docs.aws.amazon.com/general/latest/gr/acct-identifiers.html for details).
 
 ### Azure
 

--- a/manage_projects.rb
+++ b/manage_projects.rb
@@ -371,7 +371,6 @@ def add_project
     metadata["regions"] = regions
     metadata["access_key_ident"] = get_non_blank("Access Key Id")
     metadata["key"] = get_non_blank("Secret Access Key")
-    metadata["account_id"] = get_non_blank("Account Id Number")
     valid = false
     while !valid
       print "Filtering level (tag/account): "

--- a/models/aws_project.rb
+++ b/models/aws_project.rb
@@ -54,10 +54,6 @@ class AwsProject < Project
     regions.join(", ")
   end
 
-  def account_id 
-    @metadata['account_id']
-  end
-
   def filter_level
     @metadata['filter_level']
   end

--- a/models/aws_project.rb
+++ b/models/aws_project.rb
@@ -630,7 +630,7 @@ class AwsProject < Project
   private
 
   def compute_cost_query(start_date, end_date=(start_date + 1), granularity="DAILY")
-    {
+    query = {
       time_period: {
         start: start_date.to_s,
         end: end_date.to_s
@@ -659,14 +659,15 @@ class AwsProject < Project
               values: ["true"]
             }
           },
-          project_filter
         ]
       },
     }
+    query[:filter][:and] << project_filter if filter_level == "tag"
+    query
   end
 
   def all_costs_query(start_date, end_date=(start_date + 1), granularity="DAILY")
-    {
+    query = {
       time_period: {
         start: "#{start_date.to_s}",
         end: "#{end_date.to_s}"
@@ -691,14 +692,15 @@ class AwsProject < Project
               }
             }
           },
-          project_filter
         ]
       },
     }
+    query[:filter][:and] << project_filter if filter_level == "tag"
+    query
   end
 
   def compute_instance_type_usage_query(start_date, end_date=start_date + 1.day)
-    {
+    query = {
       time_period: {
         start: start_date.to_s,
         end: end_date.to_s
@@ -719,7 +721,6 @@ class AwsProject < Project
               values: ["EC2: Running Hours"]
             }
           },
-          project_filter,
           {
             tags: {
               key: "compute",
@@ -730,10 +731,12 @@ class AwsProject < Project
       },
       group_by: [{type: "DIMENSION", key: "INSTANCE_TYPE"}]
     }
+    query[:filter][:and] << project_filter if filter_level == "tag"
+    query
   end
 
   def data_out_query(start_date, end_date=start_date + 1, granularity="DAILY")
-    {
+    query = {
       time_period: {
         start: start_date.to_s,
         end: end_date.to_s
@@ -753,7 +756,6 @@ class AwsProject < Project
               ]
             }
           },
-          project_filter,
           {
             not: {
               dimensions: {
@@ -773,6 +775,8 @@ class AwsProject < Project
         ]
       }
     }
+    query[:filter][:and] << project_filter if filter_level == "tag"
+    query
   end
 
   def instances_info_query(region, token=nil)
@@ -821,34 +825,16 @@ class AwsProject < Project
           }, 
         ], 
       }
-    else
-      {
-        filters: [
-          {
-            name: "owner-id",
-            values: [self.account_id]
-          }
-        ]
-      }
     end
   end
 
   def project_filter
-    if filter_level == "tag"
-      {
-        tags: {
-          key: "project",
-          values: [self.name]
-        }
+    {
+      tags: {
+        key: "project",
+        values: [self.name]
       }
-    else
-      {
-        dimensions: {
-          key: "LINKED_ACCOUNT",
-          values: [self.account_id]
-        }
-      }
-    end
+    }
   end
 end
 


### PR DESCRIPTION
Currently for AWS projects, the reporter filters either by project tag or account id, depending upon the value set for the project's `project_filter` attribute. We in fact do not want to filter by account id, as we also want to include costs & usage for any associated sub accounts. This PR therefore removes that filter.