### PR TITLE
Improved Azure error reporting

### DIFF
--- a/daily_reports.rb
+++ b/daily_reports.rb
@@ -36,7 +36,7 @@ def all_projects(date, slack, text, rerun, verbose, customer_facing, short)
       error = <<~MSG
       Generation of daily report for project *#{project.name}* stopped due to error:
       #{e}
-      #{e.error_messages}
+      #{e.error_messages.join("\n")}
       MSG
 
       project.send_slack_message(error) if slack

--- a/daily_reports.rb
+++ b/daily_reports.rb
@@ -36,6 +36,7 @@ def all_projects(date, slack, text, rerun, verbose, customer_facing, short)
       error = <<~MSG
       Generation of daily report for project *#{project.name}* stopped due to error:
       #{e}
+      #{e.error_messages}
       MSG
 
       project.send_slack_message(error) if slack
@@ -88,6 +89,7 @@ if ARGV[0] && ARGV[0] != "all"
   rescue AzureApiError, AwsSdkError => e
     puts "Generation of daily report for project #{project.name} stopped due to error: "
     puts e
+    puts e.error_messages
   end
 else
   all_projects(date, slack, text, rerun, verbose, customer_facing, short)

--- a/daily_reports.rb
+++ b/daily_reports.rb
@@ -36,7 +36,7 @@ def all_projects(date, slack, text, rerun, verbose, customer_facing, short)
       error = <<~MSG
       Generation of daily report for project *#{project.name}* stopped due to error:
       #{e}
-      #{e.error_messages.join("\n")}
+      #{e.error_messages.join}
       MSG
 
       project.send_slack_message(error) if slack

--- a/models/aws_project.rb
+++ b/models/aws_project.rb
@@ -835,4 +835,9 @@ class AwsProject < Project
 end
 
 class AwsSdkError < StandardError
+  attr_accessor :error_messages
+  def initialize(msg)
+    @error_messages = []
+    super(msg)
+  end
 end

--- a/models/azure_project.rb
+++ b/models/azure_project.rb
@@ -558,8 +558,11 @@ class AzureProject < Project
       end
     rescue Net::ReadTimeout
       if attempt < MAX_API_ATTEMPTS
-        error.error_messages.append("Attempt #{attempt}:\nError code #{response.code}."\
-                                    "\n#{response if @verbose}")
+        msg = "Attempt #{attempt}: Request timed out.\n"
+        if response
+          msg << "Error code #{response.code}.\n#{response if @verbose}\n"
+        end
+        error.error_messages.append(msg)
         retry
       else
         raise error
@@ -600,8 +603,10 @@ class AzureProject < Project
         raise AzureApiError.new("Error querying daily cost Azure API for project #{name}.\nError code #{response.code}.\n#{response if @verbose}")
       end
     rescue Net::ReadTimeout
-      error.error_messages.append("Attempt #{attempt}:\nError code #{response.code}."\
-                                  "\n#{response if @verbose}")
+      msg = "Attempt #{attempt}: Request timed out.\n"
+      if response
+        msg << "Error code #{response.code}.\n#{response if @verbose}\n"
+      end
       if attempt < MAX_API_ATTEMPTS
         retry
       else
@@ -644,8 +649,10 @@ class AzureProject < Project
       end
     rescue Net::ReadTimeout
       if attempt < MAX_API_ATTEMPTS
-        error.error_messages.append("Attempt #{attempt}:\nError code #{response.code}."\
-                                    "\n#{response if @verbose}")
+        msg = "Attempt #{attempt}: Request timed out.\n"
+        if response
+          msg << "Error code #{response.code}.\n#{response if @verbose}\n"
+        end
         retry
       else
         raise error
@@ -686,8 +693,10 @@ class AzureProject < Project
       end
     rescue Net::ReadTimeout
       if attempt < MAX_API_ATTEMPTS
-        error.error_messages.append("Attempt #{attempt}:\nError code #{response.code}."\
-                                    "\n#{response if @verbose}")
+        msg = "Attempt #{attempt}: Request timed out.\n"
+        if response
+          msg << "Error code #{response.code}.\n#{response if @verbose}\n"
+        end
         retry
       else
         raise error
@@ -746,8 +755,10 @@ class AzureProject < Project
         end
       rescue Net::ReadTimeout
         if attempt < MAX_API_ATTEMPTS
-          error.error_messages.append("Attempt #{attempt}:\nError code #{response.code}."\
-                                      "\n#{response if @verbose}")
+        msg = "Attempt #{attempt}: Request timed out.\n"
+        if response
+          msg << "Error code #{response.code}.\n#{response if @verbose}\n"
+        end
           retry
         else
           raise error
@@ -817,8 +828,10 @@ class AzureProject < Project
         end
       rescue Net::ReadTimeout
         if attempt < MAX_API_ATTEMPTS
-          error.error_messages.append("Attempt #{attempt}:\nError code #{response.code}."\
-                                      "\n#{response.code if @verbose}")
+          msg = "Attempt #{attempt}: Request timed out.\n"
+          if response
+            msg << "Error code #{response.code}.\n#{response if @verbose}\n"
+          end
           retry
         else
           raise error

--- a/models/azure_project.rb
+++ b/models/azure_project.rb
@@ -550,7 +550,7 @@ class AzureProject < Project
       if response.success?
         vms = response['value']
         vms.select { |vm| vm.key?('tags') && vm['tags']['type'] == 'compute' && self.resource_groups.include?(vm['id'].split('/')[4].downcase) }
-      elsif response.code == 504 && attempt < MAX_API_ATTEMPTS
+      elsif response.code == 504
         raise Net::ReadTimeout
       else
         raise AzureApiError.new("Error querying compute nodes for project #{name}."\
@@ -594,7 +594,7 @@ class AzureProject < Project
       )
       if response.success?
         details = response['value']
-      elsif response.code == 504 && attempt < MAX_API_ATTEMPTS
+      elsif response.code == 504
         raise Net::ReadTimeout
       else
         raise AzureApiError.new("Error querying daily cost Azure API for project #{name}.\nError code #{response.code}.\n#{response if @verbose}")
@@ -637,7 +637,7 @@ class AzureProject < Project
             end
           end
         end
-      elsif response.code == 504 && attempt < MAX_API_ATTEMPTS
+      elsif response.code == 504
         raise Net::ReadTimeout
       else
         raise AzureApiError.new("Error querying node status Azure API for project #{name}.\nError code #{response.code}.\n#{response if @verbose}")
@@ -679,7 +679,7 @@ class AzureProject < Project
         @metadata['bearer_expiry'] = body['expires_on']
         self.metadata = @metadata.to_json
         self.save
-      elsif response.code == 504 && attempt < MAX_API_ATTEMPTS
+      elsif response.code == 504
         raise Net::ReadTimeout
       else
         raise AzureApiError.new("Error obtaining new authorization token for project #{name}.\nError code #{response.code}\n#{response if @verbose}")
@@ -739,7 +739,7 @@ class AzureProject < Project
               File.write("azure_prices.txt", "\n", mode: "a")
             end
           end
-        elsif response.code == 504 && attempt < MAX_API_ATTEMPTS
+        elsif response.code == 504
           raise Net::ReadTimeout
         else
           raise AzureApiError.new("Error obtaining latest Azure price list. Error code #{response.code}.\n#{response if @verbose}")
@@ -810,7 +810,7 @@ class AzureProject < Project
               File.write("azure_instance_sizes.txt", "\n", mode: "a")
             end
           end
-        elsif response.code == 504 && attempt < MAX_API_ATTEMPTS
+        elsif response.code == 504
           raise Net::ReadTimeout
         else
           raise AzureApiError.new("Error obtaining latest Azure instance list. Error code #{response.code}.\n#{response if @verbose}")

--- a/models/azure_project.rb
+++ b/models/azure_project.rb
@@ -557,12 +557,12 @@ class AzureProject < Project
                                 "\nError code #{response.code}.\n#{response if @verbose}")
       end
     rescue Net::ReadTimeout
+      msg = "Attempt #{attempt}: Request timed out.\n"
+      if response
+        msg << "Error code #{response.code}.\n#{response if @verbose}\n"
+      end
+      error.error_messages.append(msg)
       if attempt < MAX_API_ATTEMPTS
-        msg = "Attempt #{attempt}: Request timed out.\n"
-        if response
-          msg << "Error code #{response.code}.\n#{response if @verbose}\n"
-        end
-        error.error_messages.append(msg)
         retry
       else
         raise error
@@ -649,12 +649,12 @@ class AzureProject < Project
         raise AzureApiError.new("Error querying node status Azure API for project #{name}.\nError code #{response.code}.\n#{response if @verbose}")
       end
     rescue Net::ReadTimeout
+      msg = "Attempt #{attempt}: Request timed out.\n"
+      if response
+        msg << "Error code #{response.code}.\n#{response if @verbose}\n"
+      end
+      error.error_messages.append(msg)
       if attempt < MAX_API_ATTEMPTS
-        msg = "Attempt #{attempt}: Request timed out.\n"
-        if response
-          msg << "Error code #{response.code}.\n#{response if @verbose}\n"
-        end
-        error.error_messages.append(msg)
         retry
       else
         raise error
@@ -694,12 +694,12 @@ class AzureProject < Project
         raise AzureApiError.new("Error obtaining new authorization token for project #{name}.\nError code #{response.code}\n#{response if @verbose}")
       end
     rescue Net::ReadTimeout
+      msg = "Attempt #{attempt}: Request timed out.\n"
+      if response
+        msg << "Error code #{response.code}.\n#{response if @verbose}\n"
+      end
+      error.error_messages.append(msg)
       if attempt < MAX_API_ATTEMPTS
-        msg = "Attempt #{attempt}: Request timed out.\n"
-        if response
-          msg << "Error code #{response.code}.\n#{response if @verbose}\n"
-        end
-        error.error_messages.append(msg)
         retry
       else
         raise error
@@ -757,12 +757,12 @@ class AzureProject < Project
           raise AzureApiError.new("Error obtaining latest Azure price list. Error code #{response.code}.\n#{response if @verbose}")
         end
       rescue Net::ReadTimeout
+        msg = "Attempt #{attempt}: Request timed out.\n"
+        if response
+          msg << "Error code #{response.code}.\n#{response if @verbose}\n"
+        end
+        error.error_messages.append(msg)
         if attempt < MAX_API_ATTEMPTS
-          msg = "Attempt #{attempt}: Request timed out.\n"
-          if response
-            msg << "Error code #{response.code}.\n#{response if @verbose}\n"
-          end
-          error.error_messages.append(msg)
           retry
         else
           raise error
@@ -831,12 +831,12 @@ class AzureProject < Project
           raise AzureApiError.new("Error obtaining latest Azure instance list. Error code #{response.code}.\n#{response if @verbose}")
         end
       rescue Net::ReadTimeout
+        msg = "Attempt #{attempt}: Request timed out.\n"
+        if response
+          msg << "Error code #{response.code}.\n#{response if @verbose}\n"
+        end
+        error.error_messages.append(msg)
         if attempt < MAX_API_ATTEMPTS
-          msg = "Attempt #{attempt}: Request timed out.\n"
-          if response
-            msg << "Error code #{response.code}.\n#{response if @verbose}\n"
-          end
-          error.error_messages.append(msg)
           retry
         else
           raise error

--- a/models/azure_project.rb
+++ b/models/azure_project.rb
@@ -607,6 +607,7 @@ class AzureProject < Project
       if response
         msg << "Error code #{response.code}.\n#{response if @verbose}\n"
       end
+      error.error_messages.append(msg)
       if attempt < MAX_API_ATTEMPTS
         retry
       else
@@ -653,6 +654,7 @@ class AzureProject < Project
         if response
           msg << "Error code #{response.code}.\n#{response if @verbose}\n"
         end
+        error.error_messages.append(msg)
         retry
       else
         raise error
@@ -697,6 +699,7 @@ class AzureProject < Project
         if response
           msg << "Error code #{response.code}.\n#{response if @verbose}\n"
         end
+        error.error_messages.append(msg)
         retry
       else
         raise error
@@ -755,10 +758,11 @@ class AzureProject < Project
         end
       rescue Net::ReadTimeout
         if attempt < MAX_API_ATTEMPTS
-        msg = "Attempt #{attempt}: Request timed out.\n"
-        if response
-          msg << "Error code #{response.code}.\n#{response if @verbose}\n"
-        end
+          msg = "Attempt #{attempt}: Request timed out.\n"
+          if response
+            msg << "Error code #{response.code}.\n#{response if @verbose}\n"
+          end
+          error.error_messages.append(msg)
           retry
         else
           raise error
@@ -832,6 +836,7 @@ class AzureProject < Project
           if response
             msg << "Error code #{response.code}.\n#{response if @verbose}\n"
           end
+          error.error_messages.append(msg)
           retry
         else
           raise error

--- a/models/azure_project.rb
+++ b/models/azure_project.rb
@@ -600,9 +600,9 @@ class AzureProject < Project
         raise AzureApiError.new("Error querying daily cost Azure API for project #{name}.\nError code #{response.code}.\n#{response if @verbose}")
       end
     rescue Net::ReadTimeout
+      error.error_messages.append("Attempt #{attempt}:\nError code #{response.code}."\
+                                  "\n#{response if @verbose}")
       if attempt < MAX_API_ATTEMPTS
-        error.error_messages.append("Attempt #{attempt}:\nError code #{response.code}."\
-                                    "\n#{response if @verbose}")
         retry
       else
         raise error
@@ -875,7 +875,9 @@ class AzureProject < Project
 end
 
 class AzureApiError < StandardError
-  def initialize
+  attr_accessor :error_messages
+  def initialize(msg)
     @error_messages = []
+    super(msg)
   end
 end

--- a/weekly_reports.rb
+++ b/weekly_reports.rb
@@ -36,6 +36,7 @@ def all_projects(date, slack, text, rerun, verbose, customer_facing)
       error = <<~MSG
       Generation of weekly report for project #{project.name} stopped due to error:
       #{e}
+      #{e.error_messages}
       MSG
 
       project.send_slack_message(error) if slack
@@ -86,6 +87,7 @@ if ARGV[0] && ARGV[0] != "all"
   rescue AzureApiError, AwsSdkError => e
     puts "Generation of weekly report for project #{project.name} stopped due to error: "
     puts e
+    e.error_messages
   end
 else
   all_projects(date, slack, text, rerun, verbose, customer_facing)

--- a/weekly_reports.rb
+++ b/weekly_reports.rb
@@ -36,7 +36,7 @@ def all_projects(date, slack, text, rerun, verbose, customer_facing)
       error = <<~MSG
       Generation of weekly report for project #{project.name} stopped due to error:
       #{e}
-      #{e.error_messages.join("\n")}
+      #{e.error_messages.join}
       MSG
 
       project.send_slack_message(error) if slack

--- a/weekly_reports.rb
+++ b/weekly_reports.rb
@@ -36,7 +36,7 @@ def all_projects(date, slack, text, rerun, verbose, customer_facing)
       error = <<~MSG
       Generation of weekly report for project #{project.name} stopped due to error:
       #{e}
-      #{e.error_messages}
+      #{e.error_messages.join("\n")}
       MSG
 
       project.send_slack_message(error) if slack
@@ -87,7 +87,7 @@ if ARGV[0] && ARGV[0] != "all"
   rescue AzureApiError, AwsSdkError => e
     puts "Generation of weekly report for project #{project.name} stopped due to error: "
     puts e
-    e.error_messages
+    puts e.error_messages
   end
 else
   all_projects(date, slack, text, rerun, verbose, customer_facing)


### PR DESCRIPTION
This PR makes an addition to the `AzureApiError` custom exception: an instance variable named `error_messages` has been added. Now, instead of only raising an error on the final API query attempt, the error messages/return codes are saved from each of the attempts and output altogether on the final failed attempt.

Resolves #87 when merged.