### PR TITLE
Ensure azure VM instance ids consistent in logs

### DIFF
--- a/db/make_azure_ids_consistent.rb
+++ b/db/make_azure_ids_consistent.rb
@@ -1,0 +1,40 @@
+#==============================================================================
+# Copyright (C) 2020-present Alces Flight Ltd.
+#
+# This file is part of cloud-cost-reporter.
+#
+# This program and the accompanying materials are made available under
+# the terms of the Eclipse Public License 2.0 which is available at
+# <https://www.eclipse.org/legal/epl-2.0>, or alternative license
+# terms made available by Alces Flight Ltd - please direct inquiries
+# about licensing to licensing@alces-flight.com.
+#
+# cloud-cost-reporter is distributed in the hope that it will be useful, but
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, EITHER EXPRESS OR
+# IMPLIED INCLUDING, WITHOUT LIMITATION, ANY WARRANTIES OR CONDITIONS
+# OF TITLE, NON-INFRINGEMENT, MERCHANTABILITY OR FITNESS FOR A
+# PARTICULAR PURPOSE. See the Eclipse Public License 2.0 for more
+# details.
+#
+# You should have received a copy of the Eclipse Public License 2.0
+# along with cloud-cost-reporter. If not, see:
+#
+#  https://opensource.org/licenses/EPL-2.0
+#
+# For more information on cloud-cost-reporter, please visit:
+# https://github.com/openflighthpc/cloud-cost-reporter
+#==============================================================================
+require 'sqlite3'
+load './models/project_factory.rb'
+
+db = SQLite3::Database.open 'db/cost_tracker.sqlite3'
+
+AzureProject.all.each do |project|
+  project.instance_logs.each do |log|
+    id = log.instance_id
+    id.gsub!("resourcegroups", "resourceGroups")
+    id.gsub!("microsoft.compute/virtualmachines", "Microsoft.Compute/virtualMachines")
+    log.instance_id = id
+    log.save!
+  end
+end

--- a/models/azure_project.rb
+++ b/models/azure_project.rb
@@ -316,10 +316,10 @@ class AzureProject < Project
         instance_id.gsub!("resourcegroups", "resourceGroups")
         instance_id.gsub!("microsoft.compute/virtualmachines", "Microsoft.Compute/virtualMachines")
         name = node['id'].match(/virtualMachines\/(.*)\/providers/i)[1]
-        resource_group = node['id'].split("/")[2].downcase
+        resource_group = node['id'].split("/")[4].downcase
         region = node['location']
         cnode = today_compute_nodes.detect do |compute_node|
-                  compute_node['name'] == name  && resource_group == compute_node['id'].split("/")[2].downcase
+                  compute_node['name'] == name  && resource_group == compute_node['id'].split("/")[4].downcase
                 end
         type = cnode['properties']['hardwareProfile']['vmSize']
         compute = cnode.key?('tags') && cnode['tags']['type'] == 'compute'


### PR DESCRIPTION
Recently the Azure APIs are inconsistently returning VM ids with lowercase/capitalised versions of some words: `resourceGroups/resourcegroups`, `virtualMachines/virtualmachines` and `Microsoft.Compute/microsoft.compute`. This can make searching for logs with the same instance id problematic (something that will shortly become important for the `cloud-cost-visualiser`).

This PR therefore converts the VM ids returned by the Azure APIs to always have a consistent, capitalised format before saving in an `InstanceLog`.

- Also adds the file `ruby db/make_azure_ids_consistent.rb` for updating an existing database
- Also adds a check for resource group when determining if an instance is a compute instance or not, as can have instances with the same name in different groups