### PR TITLE
filter out duplicated Azure cost entries

### DIFF
--- a/models/azure_project.rb
+++ b/models/azure_project.rb
@@ -616,9 +616,16 @@ class AzureProject < Project
         details = response['value']
         # Sometimes Azure will duplicate each cost item. We know there are exactly two of each in this situation
         # so can sort so sequential and then remove every other item
-        if details.length > 1 && details.count { |cost| cost["id"] == details[0]["id"] } > 1
-          details.sort_by! { |cost| cost["id"] }
-          filtered_details = details.select.with_index { |cost, index| index % 2 == 0 } 
+        if details.length > 1
+          dupe_count = 0
+          details.each do |cost|
+            break if dupe_count > 1
+            dupe_count += 1 if cost["id"] == details[0]["id"]
+          end
+          if dupe_count > 1
+            details.sort_by! { |cost| cost["id"] }
+            filtered_details = details.select.with_index { |cost, index| index % 2 == 0 } 
+          end
         end
         filtered_details ? filtered_details : details
       elsif response.code == 504

--- a/models/azure_project.rb
+++ b/models/azure_project.rb
@@ -614,9 +614,10 @@ class AzureProject < Project
       )
       if response.success?
         details = response['value']
-        # Sometimes Azure will duplicate each cost item. We know the dupes are in sequential pairs
-        # so if this the case, only include the first copy of each.
-        if details.length > 1 && details[0]["id"] == details[1]["id"]
+        # Sometimes Azure will duplicate each cost item. We know there are exactly two of each in this situation
+        # so can sort so sequential and then remove every other item
+        if details.length > 1 && details.count { |cost| cost["id"] == details[0]["id"] } > 1
+          details.sort_by! { |cost| cost["id"] }
           filtered_details = details.select.with_index { |cost, index| index % 2 == 0 } 
         end
         filtered_details ? filtered_details : details

--- a/models/azure_project.rb
+++ b/models/azure_project.rb
@@ -614,6 +614,12 @@ class AzureProject < Project
       )
       if response.success?
         details = response['value']
+        # Sometimes Azure will duplicate each cost item. We know the dupes are in sequential pairs
+        # so if this the case, only include the first copy of each.
+        if details.length > 1 && details[0]["id"] == details[1]["id"]
+          filtered_details = details.select.with_index { |cost, index| index % 2 == 0 } 
+        end
+        filtered_details ? filtered_details : details
       elsif response.code == 504
         raise Net::ReadTimeout
       else


### PR DESCRIPTION
Aims to resolve #113

- Checks if the cost entries received from the Azure API are duplicated and if so, removes the dupes

**Implementation Detail**
- As far as we know there will always be one copy of each cost, or two copies of each cost
- Check for dupes by counting costs with the same id as the first cost entry. Stop once more than 1 found (to prevent searching the entire array of costs, which can be very large)
- If there are dupes, we sort all costs by id so dupes are sequential (i.e. each initial cost entry will be followed by its dupe) and then remove every other cost entry
- This is much more efficient than using ruby's `.uniq`, which was also explored, but was extremely slow and may be too memory intensive if a very large number of records
- If the Azure API starts adding more than 1 dupe/ only dupes for some costs, this workaround will need updating

At the time of writing the Azure API sometimes does and sometimes does not return the duplicated costs. Sometimes these dupes are sequential, sometimes they are not.