### PR TITLE
updated cu conversion

### DIFF
--- a/models/aws_project.rb
+++ b/models/aws_project.rb
@@ -197,16 +197,16 @@ class AwsProject < Project
       start_date = start_date > date.beginning_of_month ? start_date : date.beginning_of_month
       compute_costs_this_month = @explorer.get_cost_and_usage(compute_cost_query(start_date, date + 1, "MONTHLY")).results_by_time[0]
       compute_costs = compute_costs_this_month.total["UnblendedCost"][:amount].to_f
-      compute_costs = (compute_costs * CostLog::USD_GBP_CONVERSION * 10 * 1.25).ceil
+      compute_costs = (compute_costs * CostLog::USD_GBP_CONVERSION * 12.5 * 1.25).ceil
 
       data_egress_this_month = @explorer.get_cost_and_usage(data_out_query(start_date, date + 1, "MONTHLY")).results_by_time[0]
       data_egress_amount = data_egress_this_month.total["UsageQuantity"][:amount].to_f.ceil(2)
       data_egress_costs = data_egress_this_month.total["UnblendedCost"][:amount].to_f
-      data_egress_costs = (data_egress_costs * CostLog::USD_GBP_CONVERSION * 10 * 1.25).ceil
+      data_egress_costs = (data_egress_costs * CostLog::USD_GBP_CONVERSION * 12.5 * 1.25).ceil
 
       costs_this_month = @explorer.get_cost_and_usage(all_costs_query(start_date, date + 1, "MONTHLY")).results_by_time[0]
       total_costs = costs_this_month.total["UnblendedCost"][:amount].to_f
-      total_costs = (total_costs * CostLog::USD_GBP_CONVERSION * 10 * 1.25).ceil
+      total_costs = (total_costs * CostLog::USD_GBP_CONVERSION * 12.5 * 1.25).ceil
 
       latest_logs = self.instance_logs.where('timestamp LIKE ?', "%#{date == DEFAULT_DATE ? Date.today : date}%").where(compute: 1)
       instances_date = latest_logs.first ? Time.parse(latest_logs.first.timestamp) : (date == DEFAULT_DATE ? Time.now : date + 0.5)
@@ -221,7 +221,7 @@ class AwsProject < Project
           end
         end
       end
-      inbetween_costs = (inbetween_costs * CostLog::USD_GBP_CONVERSION * 24 * 10 * 1.25).ceil
+      inbetween_costs = (inbetween_costs * CostLog::USD_GBP_CONVERSION * 24 * 12.5 * 1.25).ceil
       inbetween_costs = (inbetween_costs + (fixed_daily_cu_cost * inbetween_dates.count)).ceil
 
       future_costs = 0.0
@@ -230,7 +230,7 @@ class AwsProject < Project
           future_costs += @@prices[log.region][log.instance_type]
         end
       end
-      daily_future_cu = (future_costs * CostLog::USD_GBP_CONVERSION * 24 * 10 * 1.25).ceil
+      daily_future_cu = (future_costs * CostLog::USD_GBP_CONVERSION * 24 * 12.5 * 1.25).ceil
       total_future_cu = (daily_future_cu + fixed_daily_cu_cost).ceil
 
       remaining_budget = self.current_budget.to_i - total_costs

--- a/models/azure_project.rb
+++ b/models/azure_project.rb
@@ -196,7 +196,7 @@ class AzureProject < Project
                      0.0
                    end
       total_costs ||= 0.0
-      total_costs = (total_costs * 10 * 1.25).ceil
+      total_costs = (total_costs * 12.5 * 1.25).ceil
 
       data_out_costs = costs_this_month.select do |cost|
         cost['properties']["additionalInfo"] &&
@@ -209,7 +209,7 @@ class AzureProject < Project
         data_out_cost += cost['properties']['cost']
         data_out_amount += cost['properties']['quantity']
       end
-      data_out_cost = (data_out_cost * 10 * 1.25).ceil
+      data_out_cost = (data_out_cost * 12.5 * 1.25).ceil
 
       compute_nodes = self.instance_logs.where(compute: 1).where('timestamp LIKE ?', "%#{start_date.to_s[0..6]}%")
       compute_costs_this_month = costs_this_month.select { |cd| compute_nodes.any? { |node| node.instance_name == cd['properties']['resourceName'] } }
@@ -219,7 +219,7 @@ class AzureProject < Project
                      0.0
                    end
       compute_costs ||= 0.0
-      compute_costs = (compute_costs * 10 * 1.25).ceil
+      compute_costs = (compute_costs * 12.5 * 1.25).ceil
 
       latest_logs = self.instance_logs.where('timestamp LIKE ?', "%#{date == DEFAULT_DATE ? Date.today : date}%").where(compute: 1)
       instances_date = latest_logs.first ? Time.parse(latest_logs.first.timestamp) : (date == DEFAULT_DATE ? Time.now : date + 0.5)
@@ -235,7 +235,7 @@ class AzureProject < Project
           end
         end
       end
-      inbetween_costs = (inbetween_costs * 24 * 10 * 1.25).ceil
+      inbetween_costs = (inbetween_costs * 24 * 12.5 * 1.25).ceil
       inbetween_costs = (inbetween_costs + (fixed_daily_cu_cost * inbetween_dates.count)).ceil
 
       future_costs = 0.0
@@ -245,7 +245,7 @@ class AzureProject < Project
           future_costs += @@prices[@@region_mappings[log.region]][type][0]
         end
       end
-      daily_future_cu = (future_costs * 24 * 10 * 1.25).ceil
+      daily_future_cu = (future_costs * 24 * 12.5 * 1.25).ceil
       total_future_cu = (daily_future_cu + fixed_daily_cu_cost).ceil
 
       remaining_budget = current_budget.to_i - total_costs

--- a/models/cost_log.rb
+++ b/models/cost_log.rb
@@ -35,7 +35,7 @@ class CostLog < ActiveRecord::Base
 
   def compute_cost
     gbp_cost = self.currency == "USD" ? (self.cost.to_f * USD_GBP_CONVERSION) : self.cost.to_f
-    (gbp_cost * 10).ceil
+    (gbp_cost * 12.5).ceil
   end
 
   def risk_cost


### PR DESCRIPTION
Updates the conversion rate of GBP to compute units: now 1GBP = 12.5 compute units (previously 10).

Not implemented here, but future improvement would be to change this to a constant and/or environment variable somewhere so easier to change.