### PR TITLE
handle sometimes uppercase resource groups

### DIFF
--- a/db/make_azure_ids_consistent.rb
+++ b/db/make_azure_ids_consistent.rb
@@ -34,6 +34,9 @@ AzureProject.all.each do |project|
     id = log.instance_id
     id.gsub!("resourcegroups", "resourceGroups")
     id.gsub!("microsoft.compute/virtualmachines", "Microsoft.Compute/virtualMachines")
+    id_breakdown = id.split("/")
+    id_breakdown[4] = id_breakdown[4].downcase
+    id = id_breakdown.join("/")
     log.instance_id = id
     log.save!
   end

--- a/models/azure_project.rb
+++ b/models/azure_project.rb
@@ -315,8 +315,12 @@ class AzureProject < Project
         instance_id = node['id']
         instance_id.gsub!("resourcegroups", "resourceGroups")
         instance_id.gsub!("microsoft.compute/virtualmachines", "Microsoft.Compute/virtualMachines")
+        instance_id_breakdown = instance_id.split("/")
+        resource_group = instance_id_breakdown[4].downcase # sometimes Azure gives it uppercase, sometime lowercase
+        instance_id_breakdown[4] = resource_group
+        instance_id = instance_id_breakdown.join("/")
+ 
         name = node['id'].match(/virtualMachines\/(.*)\/providers/i)[1]
-        resource_group = node['id'].split("/")[4].downcase
         region = node['location']
         cnode = today_compute_nodes.detect do |compute_node|
                   compute_node['name'] == name  && resource_group == compute_node['id'].split("/")[4].downcase


### PR DESCRIPTION
Aims to resolve #119

- Accommodates Azure API giving instance ids with their resource group sometimes in upper case and sometimes in lower case
- Before creating an azure instance log, downcases the resource group part of the id
- `ruby db/make_azure_ids_consistent` should be run for an existing database