### PR TITLE
Add timeouts to db connections

### DIFF
--- a/models/budget.rb
+++ b/models/budget.rb
@@ -27,7 +27,7 @@
 
 require 'active_record'
 
-ActiveRecord::Base.establish_connection(adapter: 'sqlite3', database: 'db/cost_tracker.sqlite3')
+ActiveRecord::Base.establish_connection(adapter: 'sqlite3', database: 'db/cost_tracker.sqlite3',  timeout: 3000)
 
 class Budget < ActiveRecord::Base
   belongs_to :project

--- a/models/cost_log.rb
+++ b/models/cost_log.rb
@@ -27,7 +27,7 @@
 
 require 'active_record'
 
-ActiveRecord::Base.establish_connection(adapter: 'sqlite3', database: 'db/cost_tracker.sqlite3')
+ActiveRecord::Base.establish_connection(adapter: 'sqlite3', database: 'db/cost_tracker.sqlite3',  timeout: 3000)
 
 class CostLog < ActiveRecord::Base
   USD_GBP_CONVERSION = ENV['USD_GBP_CONVERSION'] ? ENV['USD_GBP_CONVERSION'].to_f : 0.77

--- a/models/customer.rb
+++ b/models/customer.rb
@@ -27,7 +27,7 @@
 
 require 'active_record'
 
-ActiveRecord::Base.establish_connection(adapter: 'sqlite3', database: 'db/cost_tracker.sqlite3')
+ActiveRecord::Base.establish_connection(adapter: 'sqlite3', database: 'db/cost_tracker.sqlite3',  timeout: 3000)
 
 class Customer < ActiveRecord::Base
   has_many :projects

--- a/models/instance_log.rb
+++ b/models/instance_log.rb
@@ -28,7 +28,7 @@
 require 'active_record'
 require_relative 'instance_mapping'
 
-ActiveRecord::Base.establish_connection(adapter: 'sqlite3', database: 'db/cost_tracker.sqlite3')
+ActiveRecord::Base.establish_connection(adapter: 'sqlite3', database: 'db/cost_tracker.sqlite3',  timeout: 3000)
 
 class InstanceLog < ActiveRecord::Base
   belongs_to :project

--- a/models/instance_mapping.rb
+++ b/models/instance_mapping.rb
@@ -27,7 +27,7 @@
 
 require 'active_record'
 
-ActiveRecord::Base.establish_connection(adapter: 'sqlite3', database: 'db/cost_tracker.sqlite3')
+ActiveRecord::Base.establish_connection(adapter: 'sqlite3', database: 'db/cost_tracker.sqlite3',  timeout: 3000)
 
 class InstanceMapping < ActiveRecord::Base
   validates :instance_type, uniqueness: true

--- a/models/project.rb
+++ b/models/project.rb
@@ -33,7 +33,7 @@ require_relative 'instance_log'
 require_relative 'usage_log'
 require_relative 'budget'
 
-ActiveRecord::Base.establish_connection(adapter: 'sqlite3', database: 'db/cost_tracker.sqlite3')
+ActiveRecord::Base.establish_connection(adapter: 'sqlite3', database: 'db/cost_tracker.sqlite3',  timeout: 3000)
 
 class Project < ActiveRecord::Base
   FIXED_MONTHLY_CU_COST = 5000

--- a/models/usage_log.rb
+++ b/models/usage_log.rb
@@ -27,7 +27,7 @@
 
 require 'active_record'
 
-ActiveRecord::Base.establish_connection(adapter: 'sqlite3', database: 'db/cost_tracker.sqlite3')
+ActiveRecord::Base.establish_connection(adapter: 'sqlite3', database: 'db/cost_tracker.sqlite3',  timeout: 3000)
 
 class UsageLog < ActiveRecord::Base
   belongs_to :project

--- a/models/weekly_report_log.rb
+++ b/models/weekly_report_log.rb
@@ -27,7 +27,7 @@
 
 require 'active_record'
 
-ActiveRecord::Base.establish_connection(adapter: 'sqlite3', database: 'db/cost_tracker.sqlite3')
+ActiveRecord::Base.establish_connection(adapter: 'sqlite3', database: 'db/cost_tracker.sqlite3',  timeout: 3000)
 
 class WeeklyReportLog < ActiveRecord::Base
   belongs_to :project


### PR DESCRIPTION
Aims to resolve #121

- Adds a timeout of 3 seconds for attempts to connect to the database (by default this is 0)
- This prevents locking errors when trying to run two scripts at the same time (e.g. `ruby daily_reports.rb` and `ruby record_instance_logs.rb`)
- If further locking errors seen, the timeout may need to be adjusted
- SQLite is not well suited for concurrent connections, so in the longer term migrating to PostgreSQL may be prudent 