### PR TITLE
Separate project tag field

### DIFF
--- a/README.md
+++ b/README.md
@@ -23,7 +23,7 @@ ruby db/add_instance_mappings.rb
 
 ### AWS
 
-On AWS, projects can be tracked on an account or project tag level. For tracking by project tag, ensure that all desired resources are given a tag with the key `project` and a value of what you have named the project. Account level will include any subaccounts.
+On AWS, projects can be tracked on an account or project tag level. For tracking by project tag, ensure that all desired resources are given a tag with the key `project` and the same value as `project_tag` saved for the project. Account level will include any subaccounts.
 
 ##### Resource tagging
 
@@ -32,6 +32,8 @@ When creating an instance via the AWS online console, any specified tags will be
 When creating instances via CloudFormation, related resources will need to be explicitly tagged regardless of when you add tags to the instance (see https://aws.amazon.com/premiumsupport/knowledge-center/cloudformation-instance-tag-root-volume/ for more details).
 
 It is recommended to check that all expected resources (IPs, volumes, etc/) have the expected tag before configuring the project tracking. It is recommended that tags are added even if the intention is to track by account, to allow for greater flexibility and accuracy if a second project is later added to the same account.
+
+Please note that if you change a project's `filter_level` and/or `project_tag` and generate new cost logs for a prior date, this will overwrite the data using the current filter level/ project tag.
 
 ##### Node type specificity
 

--- a/db/add_project_tags.rb
+++ b/db/add_project_tags.rb
@@ -1,0 +1,39 @@
+#==============================================================================
+# Copyright (C) 2020-present Alces Flight Ltd.
+#
+# This file is part of cloud-cost-reporter.
+#
+# This program and the accompanying materials are made available under
+# the terms of the Eclipse Public License 2.0 which is available at
+# <https://www.eclipse.org/legal/epl-2.0>, or alternative license
+# terms made available by Alces Flight Ltd - please direct inquiries
+# about licensing to licensing@alces-flight.com.
+#
+# cloud-cost-reporter is distributed in the hope that it will be useful, but
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, EITHER EXPRESS OR
+# IMPLIED INCLUDING, WITHOUT LIMITATION, ANY WARRANTIES OR CONDITIONS
+# OF TITLE, NON-INFRINGEMENT, MERCHANTABILITY OR FITNESS FOR A
+# PARTICULAR PURPOSE. See the Eclipse Public License 2.0 for more
+# details.
+#
+# You should have received a copy of the Eclipse Public License 2.0
+# along with cloud-cost-reporter. If not, see:
+#
+#  https://opensource.org/licenses/EPL-2.0
+#
+# For more information on cloud-cost-reporter, please visit:
+# https://github.com/openflighthpc/cloud-cost-reporter
+#==============================================================================
+
+require 'sqlite3'
+load './models/aws_project.rb'
+
+db = SQLite3::Database.open 'db/cost_tracker.sqlite3'
+
+db.execute "ALTER TABLE projects
+ADD COLUMN project_tag TEXT;"
+
+AwsProject.where(filter_level: "tag").each do |project|
+  project.project_tag = project.name
+  project.save!
+end

--- a/db/setup.rb
+++ b/db/setup.rb
@@ -40,6 +40,7 @@ db.execute "CREATE TABLE IF NOT EXISTS projects(
   id INTEGER PRIMARY KEY AUTOINCREMENT,
   client_id INTEGER,
   host TEXT,
+  project_tag TEXT,
   filter_level TEXT,
   start_date TEXT,
   end_date TEXT,

--- a/models/aws_project.rb
+++ b/models/aws_project.rb
@@ -978,7 +978,7 @@ class AwsProject < Project
         filters: [
           {
             name: "tag:project", 
-            values: [self.name], 
+            values: [self.project_tag], 
           }, 
         ], 
       }
@@ -989,7 +989,7 @@ class AwsProject < Project
     {
       tags: {
         key: "project",
-        values: [self.name]
+        values: [self.project_tag]
       }
     }
   end

--- a/models/aws_project.rb
+++ b/models/aws_project.rb
@@ -40,6 +40,7 @@ class AwsProject < Project
       in: %w(tag account),
       message: "%{value} is not a valid filter level. Must be tag or account."
     }
+  validate :project_tag_if_tag_filter
   after_initialize :add_sdk_objects
 
   default_scope { where(host: "aws") }
@@ -712,6 +713,10 @@ class AwsProject < Project
   end
 
   private
+
+  def project_tag_if_tag_filter
+    errors.add(:project_tag, "Must be defined if filter level is tag") if self.filter_level == "tag" && !project_tag
+  end
 
   def compute_cost_query(start_date, end_date=(start_date + 1), granularity="DAILY", group=nil)
     query = {


### PR DESCRIPTION
Aims to resolve #124

- For AWS projects, if `filter_level` is "tag", must specify a value for new attribute `project_tag`
- This allows for the project tag to be different from the project name
- For an existing database, `ruby db/add_project_tags.rb` must be run
- Project tags can be updated using `ruby manage_projects.rb`

This may impact https://github.com/openflighthpc/cloud-cost-visualiser/issues/142