### PR TITLE
Fix display of resource groups as option to change

### DIFF
--- a/manage_projects.rb
+++ b/manage_projects.rb
@@ -54,7 +54,7 @@ def add_or_update_project(action=nil)
     puts "budget: #{project.current_budget}c.u./month"
     puts "regions: #{project.regions.join(", ")}" if project.aws?
     puts "filter_level: #{project.filter_level}"
-    puts "resource_groups: #{project.resource_groups.join(", ")}" if project.azure? && project.filter_level == "resource groups"
+    puts "resource_groups: #{project.resource_groups.join(", ")}" if project.azure? && project.filter_level == "resource group"
     puts "slack_channel: #{project.slack_channel}"
     puts "metadata: (hidden)\n"
     update_attributes(project)


### PR DESCRIPTION
Fixes a typo in `manage_projects.rb` that prevented `resource_groups` from being listed as one of the possible attributes to change (when applicable).