### PR TITLE
Consistent compute and core type tagging

### DIFF
--- a/README.md
+++ b/README.md
@@ -35,7 +35,7 @@ It is recommended to check that all expected resources (IPs, volumes, etc/) have
 
 ##### Node type specificity
 
-This application includes in its breakdown details of instances specifically used as compute nodes. For this to be measured accurately, the appropriate instances should have a tag added with the key `compute` and the value `true`. Again, these should be added at the point of creation. If compute groups are also being used, these should be added using the tag `compute_group`, with a value of the group name. Similarly, core infrastructure can be identified using a tag with the key `core` and the value `true`.
+This application includes in its breakdown details of instances specifically used as compute nodes. For this to be measured accurately, the appropriate instances should have a tag added with the key `type` and the value `compute`. Again, these should be added at the point of creation. If compute groups are also being used, these should be added using the tag `compute_group`, with a value of the group name. Similarly, core infrastructure can be identified using a tag with the key `type` and the value `core`.
 
 ##### Admin
 

--- a/models/aws_project.rb
+++ b/models/aws_project.rb
@@ -618,8 +618,8 @@ class AwsProject < Project
               if tag.key == "Name"
                 named = tag.value
               end
-              if tag.key == "compute"
-                compute = tag.value == "true"
+              if tag.key == "type"
+                compute = tag.value == "compute"
               end
               if tag.key == "compute_group"
                 compute_group = tag.value
@@ -745,8 +745,8 @@ class AwsProject < Project
           },
           {
             tags: {
-              key: "compute",
-              values: ["true"]
+              key: "type",
+              values: ["compute"]
             }
           },
         ]
@@ -783,8 +783,8 @@ class AwsProject < Project
           },
           {
             tags: {
-              key: "core",
-              values: ["true"]
+              key: "type",
+              values: ["core"]
             }
           },
         ]
@@ -851,8 +851,8 @@ class AwsProject < Project
           },
           {
             tags: {
-              key: "compute",
-              values: ["true"]
+              key: "type",
+              values: ["compute"]
             }
           }
         ]


### PR DESCRIPTION
Aims to resolve #127 

- For AWS projects, compute resources are now identified with the tag `type => compute`
- Core resources are now identified with the tag `type => core`
- This is consistent with tagging for Azure resources

Note: This has been tested for instance logs, but not costs as it will take 3+ days for the `type` tag to become active & reflected in costs.