### PR TITLE
Handle cluster hub having times for start and end dates

### DIFF
--- a/models/project.rb
+++ b/models/project.rb
@@ -59,8 +59,8 @@ class Project < ActiveRecord::Base
       message: "%{value} is not a valid host"
     }
   scope :active, -> { 
-    where("end_date > ? OR end_date IS NULL", Date.today).where(
-          "start_date <= ?", Date.today)
+    where("end_date IS NULL OR (end_date > ? AND end_date NOT LIKE ?)", Date.today, "%#{Date.today}%").where(
+          "start_date <= ? OR start_date LIKE ?", Date.today, "%#{Date.today.to_s}%")
   }
   
   def aws?


### PR DESCRIPTION
Linked to https://github.com/openflighthpc/cluster-hub/pull/67

- Updates the active scope to accommodate the `cluster-hub` having start and end dates including times (whilst retaining current behaviour for local and cloud-cost-visualiser projects)
- In the cluster hub we never create projects with start or end times in the future
- We can therefore assume that if a cluster-hub project as a start time that includes today's date, it has started
- Similarly, if a cluster-hub project has an end date that includes today's date, we can assume it has ended