### PR TITLE
Instance log cron job

### DIFF
--- a/Rakefile
+++ b/Rakefile
@@ -13,7 +13,7 @@ end
 
 desc 'Record all instance logs'
 task :instance_logs do
-  system("ruby record_instance_logs all rerun")
+  system("ruby record_instance_logs.rb all rerun")
 end
 
 desc 'Get latest azure prices'

--- a/Rakefile
+++ b/Rakefile
@@ -11,6 +11,11 @@ task :weekly_reports do
   system("SLACK_TOKEN=#{slack_token} ruby weekly_reports.rb all latest slack")
 end
 
+desc 'Record all instance logs'
+task :instance_logs do
+  system("ruby record_instance_logs all rerun")
+end
+
 desc 'Get latest azure prices'
 task :azure_prices do
   system("ruby get_latest_azure_prices.rb")

--- a/config/schedule.rb
+++ b/config/schedule.rb
@@ -32,3 +32,7 @@ end
 every :monday, at: '12pm' do
   rake "weekly_reports"
 end
+
+every 5.minutes do
+  command "./record_instance_logs.rb all rerun"
+end

--- a/config/schedule.rb
+++ b/config/schedule.rb
@@ -34,5 +34,5 @@ every :monday, at: '12pm' do
 end
 
 every 5.minutes do
-  command "./record_instance_logs.rb all rerun"
+  command "ruby #{File.expand_path("..", File.dirname(__FILE__))}/record_instance_logs.rb all rerun"
 end

--- a/config/schedule.rb
+++ b/config/schedule.rb
@@ -34,5 +34,5 @@ every :monday, at: '12pm' do
 end
 
 every 5.minutes do
-  command "ruby #{File.expand_path("..", File.dirname(__FILE__))}/record_instance_logs.rb all rerun"
+  rake "instance_logs"
 end


### PR DESCRIPTION
This PR adds a new job to the `config/schedule.rb` file which makes sure that instance logs are refreshed every 5 minutes. The cron job it generates resembles the following:

```
0,5,10,15,20,25,30,35,40,45,50,55 * * * * /bin/bash -l -c 'ruby /path/to/cloud-cost-reporter/record_instance_logs.rb all rerun'
```

With the `/path/to` section replaced with the actual path to the reporter directory. Note that this cron syntax specifically means "at the 0th, 5th, 10th, etc. of every hour", but this is equivalent to the shorthand `*/5 * * * *`, meaning "every 5th minute".