### PR TITLE
add user id to projects

### DIFF
--- a/db/add_user_id.rb
+++ b/db/add_user_id.rb
@@ -1,0 +1,6 @@
+require 'sqlite3'
+
+db = SQLite3::Database.open 'db/cost_tracker.sqlite3'
+
+db.execute "ALTER TABLE projects
+ADD COLUMN user_id INTEGER;"

--- a/db/setup.rb
+++ b/db/setup.rb
@@ -34,6 +34,7 @@ db.execute "CREATE TABLE IF NOT EXISTS projects(
   name TEXT,
   id INTEGER PRIMARY KEY AUTOINCREMENT,
   host TEXT,
+  user_id INTEGER,
   project_tag TEXT,
   filter_level TEXT,
   start_date TEXT,


### PR DESCRIPTION
Linked to https://github.com/openflighthpc/cluster-hub/issues/71

- Adds an optional `user_id` field to `projects`
- This is to allow for the `User` model in `clusterhub` to include a 'has_many' relationship with projects
- The original hope was to avoid a change in `reporter` that is only required for `clusterhub`. However, after some investigation, the alternative of using a join table within `clusterhub` required too many workarounds, as rails 6 struggles with join tables that utilise tables in two different databases
- This does not appear to interfere with `cloud-cost-reporter` running on its own, or with `cloud-cost-visualiser`