### PR TITLE
Record final cost logs

### DIFF
--- a/README.md
+++ b/README.md
@@ -122,7 +122,7 @@ Please see https://github.com/javan/whenever for more details on using the `when
 
 The application includes functionality for generating both daily and weekly reports of cloud usage and cost data. The obtained data is saved in the database and, unless specified, queries where an existing report exists will use stored data instead of making fresh sdk/api calls.
 
-Daily reports can be generated using `ruby daily_reports.rb`. If run without any arguments, this will iterate over all Projects in the database and retrieve data for 3 days ago (as cost & usage data takes 3 days to update). The results will be printed to the terminal and posted to the chosen slack channel(s).
+Daily reports can be generated using `ruby daily_reports.rb`. If run without any arguments, this will iterate over all Projects in the database and retrieve data for 3 days ago (as cost & usage data takes 3 days to update). The results will be printed to the terminal and posted to the chosen slack channel(s). A daily report will not be generated if the cost date is earlier than a project's start date or after its end date.
 
 Weekly reports can similarly be generated using `ruby weekly_reports.rb`. If run without any arguments, this will iterate over all Projects in the database and retrieve data for the month so far, including estimating costs for the rest of the month. The results will be printed to the terminal and posted to the chosen slack channel(s). Weekly reports use the specified date (3 days ago by default) for historical cost data, and will use either use the specified date's instance information, or today's if generating the 'latest' report.
 

--- a/daily_reports.rb
+++ b/daily_reports.rb
@@ -29,7 +29,7 @@ require 'date'
 require_relative './models/project_factory'
 
 def all_projects(date, slack, text, rerun, verbose, customer_facing, short)
-  ProjectFactory.new().all_active_projects_as_type.each do |project|
+  ProjectFactory.new().all_projects_within_costs_period_as_type.each do |project|
     begin
       project.daily_report(date, slack, text, rerun, verbose, customer_facing, short)
     rescue AzureApiError, AwsSdkError => e

--- a/daily_reports.rb
+++ b/daily_reports.rb
@@ -29,7 +29,7 @@ require 'date'
 require_relative './models/project_factory'
 
 def all_projects(date, slack, text, rerun, verbose, customer_facing, short)
-  ProjectFactory.new().all_projects_within_costs_period_as_type.each do |project|
+  ProjectFactory.new().all_projects_within_costs_period_as_type(date).each do |project|
     begin
       project.daily_report(date, slack, text, rerun, verbose, customer_facing, short)
     rescue AzureApiError, AwsSdkError => e

--- a/models/aws_project.rb
+++ b/models/aws_project.rb
@@ -597,6 +597,8 @@ class AwsProject < Project
   end
 
   def record_instance_logs(rerun=false)
+    return if self.end_date # can't record instance logs if cluster is no more
+
     today_logs = self.instance_logs.where('timestamp LIKE ?', "%#{Date.today}%")
     today_logs.delete_all if rerun
     if today_logs.count == 0

--- a/models/azure_project.rb
+++ b/models/azure_project.rb
@@ -305,6 +305,8 @@ class AzureProject < Project
   end
 
   def record_instance_logs(rerun=false)
+    return if self.end_date # can't record instance logs if cluster is no more
+
     refresh_auth_token
     today_logs = self.instance_logs.where('timestamp LIKE ?', "%#{Date.today}%")
     today_logs.delete_all if rerun

--- a/models/project.rb
+++ b/models/project.rb
@@ -64,7 +64,7 @@ class Project < ActiveRecord::Base
   }
   scope :within_costs_period, -> {
     where("end_date IS NULL OR (end_date > ? AND end_date NOT LIKE ?)", DEFAULT_DATE - 1, "%#{(DEFAULT_DATE - 1).to_s}%").where(
-          "start_date <= ? OR start_date LIKE ?", DEFAULT_DATE - 1, "%#{(DEFAULT_DATE - 1).to_s}%")
+          "start_date <= ? OR start_date LIKE ?", Date.today, "%#{Date.today.to_s}%")
   }
   
   def aws?

--- a/models/project.rb
+++ b/models/project.rb
@@ -59,8 +59,12 @@ class Project < ActiveRecord::Base
       message: "%{value} is not a valid host"
     }
   scope :active, -> { 
-    where("end_date IS NULL OR (end_date > ? AND end_date NOT LIKE ?)", Date.today, "%#{Date.today}%").where(
+    where("end_date IS NULL OR (end_date > ? AND end_date NOT LIKE ?)", Date.today, "%#{Date.today.to_s}%").where(
           "start_date <= ? OR start_date LIKE ?", Date.today, "%#{Date.today.to_s}%")
+  }
+  scope :within_costs_period, -> {
+    where("end_date IS NULL OR (end_date > ? AND end_date NOT LIKE ?)", DEFAULT_DATE - 1, "%#{(DEFAULT_DATE - 1).to_s}%").where(
+          "start_date <= ? OR start_date LIKE ?", DEFAULT_DATE - 1, "%#{(DEFAULT_DATE - 1).to_s}%")
   }
   
   def aws?

--- a/models/project.rb
+++ b/models/project.rb
@@ -62,9 +62,9 @@ class Project < ActiveRecord::Base
     where("end_date IS NULL OR (end_date > ? AND end_date NOT LIKE ?)", Date.today, "%#{Date.today.to_s}%").where(
           "start_date <= ? OR start_date LIKE ?", Date.today, "%#{Date.today.to_s}%")
   }
-  scope :within_costs_period, -> {
-    where("end_date IS NULL OR (end_date > ? AND end_date NOT LIKE ?)", DEFAULT_DATE - 1, "%#{(DEFAULT_DATE - 1).to_s}%").where(
-          "start_date <= ? OR start_date LIKE ?", Date.today, "%#{Date.today.to_s}%")
+  scope :within_costs_period, -> (date = DEFAULT_DATE) {
+    where("end_date IS NULL OR (end_date > ? AND end_date NOT LIKE ?)", date - 1, "%#{(date - 1).to_s}%").where(
+          "start_date <= ? OR start_date LIKE ?", date, "%#{date.to_s}%")
   }
   
   def aws?

--- a/models/project_factory.rb
+++ b/models/project_factory.rb
@@ -39,6 +39,12 @@ class ProjectFactory
     Project.active.map { |project| as_type(project) }
   end
 
+  # include projects that have ended, but still have days we need
+  # to record cost logs for
+  def all_projects_within_costs_period_as_type
+    Project.within_costs_period.map { |project| as_type(project) }
+  end
+
   def as_type(project)
     project.aws? ? AwsProject.find(project.id) : AzureProject.find(project.id)
   end

--- a/models/project_factory.rb
+++ b/models/project_factory.rb
@@ -41,8 +41,8 @@ class ProjectFactory
 
   # include projects that have ended, but still have days we need
   # to record cost logs for
-  def all_projects_within_costs_period_as_type
-    Project.within_costs_period.map { |project| as_type(project) }
+  def all_projects_within_costs_period_as_type(date)
+    Project.within_costs_period(date).map { |project| as_type(project) }
   end
 
   def as_type(project)


### PR DESCRIPTION
Aims to resolve #131 

- Instead of just running for projects that are _currently_ active, daily reports are now run for projects that were active _on the day costs are being generated for_
- For example, if no date specified, it will run for all projects that were active 3 days ago
- This also applies if a specific date is given (e.g. if pass argument of "2021-08-01" will only run for projects that were active on 1st August)
- This means cost logs will be recorded for _all_ days a project was active
- Both AWS and Azure accept cost data requests for projects that no longer exist (though only able to test with resource group and project tag level projects)
- Also prevents attempting to record instance logs if a project has ended, as doing so will fail once a cluster no longer exists