### PR TITLE
Fix recording instance logs for projects with end date and better reporting

### DIFF
--- a/models/aws_project.rb
+++ b/models/aws_project.rb
@@ -615,6 +615,7 @@ class AwsProject < Project
     end
     today_logs.delete_all if rerun
     log_recorded = false
+    any_nodes = false
     if today_logs.count == 0
       regions.reverse.each do |region|
         begin
@@ -627,6 +628,7 @@ class AwsProject < Project
           raise AwsSdkError.new("Unable to determine AWS instances for project #{self.name} due to missing region. #{error if @verbose}")  
         end
         @instances_checker.describe_instances(project_instances_query).reservations.each do |reservation|
+          any_nodes = true if reservation.instances.any?
           reservation.instances.each do |instance|
             named = ""
             compute = false
@@ -660,7 +662,7 @@ class AwsProject < Project
         end
       end
     end
-    outcome << (log_recorded ? "Logs recorded" : "No logs to record.")
+    outcome << (log_recorded ? "Logs recorded" : (any_nodes ? "Logs NOT recorded" : "No logs to record"))
     outcome
   end
 

--- a/models/aws_project.rb
+++ b/models/aws_project.rb
@@ -597,10 +597,24 @@ class AwsProject < Project
   end
 
   def record_instance_logs(rerun=false)
-    return if self.end_date # can't record instance logs if cluster is no more
+    # can't record instance logs if project is no more
+    if self.end_date && Date.parse(self.end_date) <= Date.today
+      return "Logs not recorded, project has ended"
+    end
 
     today_logs = self.instance_logs.where('timestamp LIKE ?', "%#{Date.today}%")
+    outcome = ""
+    if today_logs.any?
+      if rerun 
+        outcome = "Overwriting existing logs. "
+      else
+        return "Logs already recorded for today. Run script again with 'rerun' to overwrite existing logs."
+      end
+    else
+      outcome = "Writing new logs for today. "
+    end
     today_logs.delete_all if rerun
+    log_recorded = false
     if today_logs.count == 0
       regions.reverse.each do |region|
         begin
@@ -629,7 +643,7 @@ class AwsProject < Project
               end
             end
 
-            InstanceLog.create(
+            log = InstanceLog.create(
               instance_id: instance.instance_id,
               project_id: self.id,
               instance_name: named,
@@ -641,10 +655,13 @@ class AwsProject < Project
               region: region,
               timestamp: Time.now.to_s
             )
+            log_recorded = true if log.valid? && log.persisted?
           end
         end
       end
     end
+    outcome << (log_recorded ? "Logs recorded" : "No logs to record.")
+    outcome
   end
 
   def get_data_out(date=DEFAULT_DATE)

--- a/models/azure_project.rb
+++ b/models/azure_project.rb
@@ -349,7 +349,7 @@ class AzureProject < Project
         compute_group = cnode.key?('tags') ? cnode['tags']['compute_group'] : nil
         log = InstanceLog.create(
           instance_id: instance_id,
-          project_id: "id",
+          project_id: id,
           instance_type: type,
           instance_name: name,
           compute: compute ? 1 : 0,
@@ -362,7 +362,7 @@ class AzureProject < Project
         log_recorded = true if log.valid? && log.persisted?
       end
     end
-    outcome << (log_recorded ? "Logs recorded" : "No logs to record.")
+    outcome << (log_recorded ? "Logs recorded" : (any_nodes ? "Logs NOT recorded" : "No logs to record"))
     outcome
   end
 

--- a/models/azure_project.rb
+++ b/models/azure_project.rb
@@ -317,7 +317,7 @@ class AzureProject < Project
       if rerun 
         outcome = "Overwriting existing logs. "
       else
-        return "Logs already recorded. Run script again with 'rerun' to overwrite existing logs."
+        return "Logs already recorded for today. Run script again with 'rerun' to overwrite existing logs."
       end
     else
       outcome = "Writing new logs for today. "
@@ -347,9 +347,9 @@ class AzureProject < Project
         type = cnode['properties']['hardwareProfile']['vmSize']
         compute = cnode.key?('tags') && cnode['tags']['type'] == 'compute'
         compute_group = cnode.key?('tags') ? cnode['tags']['compute_group'] : nil
-        InstanceLog.create(
+        log = InstanceLog.create(
           instance_id: instance_id,
-          project_id: id,
+          project_id: "id",
           instance_type: type,
           instance_name: name,
           compute: compute ? 1 : 0,
@@ -359,7 +359,7 @@ class AzureProject < Project
           region: region,
           timestamp: Time.now.to_s
         )
-        log_recorded = true
+        log_recorded = true if log.valid? && log.persisted?
       end
     end
     outcome << (log_recorded ? "Logs recorded" : "No logs to record.")

--- a/record_instance_logs.rb
+++ b/record_instance_logs.rb
@@ -30,7 +30,7 @@ require_relative './models/project_factory'
 def all_projects(rerun)
   ProjectFactory.new().all_active_projects_as_type.each do |project|
     begin
-      project.record_instance_logs(rerun)
+      puts "Project #{project.name}: #{project.record_instance_logs(rerun)}"
     rescue AzureApiError, AwsSdkError => e
       error = <<~MSG
       Generation of instance logs for project *#{project.name}* stopped due to error:
@@ -55,7 +55,7 @@ if ARGV[0] && ARGV[0] != "all"
   end
   project = ProjectFactory.new().as_type(project)
   begin
-    project.record_instance_logs(rerun)
+    puts "Project #{project.name}: #{project.record_instance_logs(rerun)}"
   rescue AzureApiError, AwsSdkError => e
     puts "Generation of instance logs for project #{project.name} stopped due to error: "
     puts e
@@ -65,4 +65,3 @@ if ARGV[0] && ARGV[0] != "all"
 else
   all_projects(rerun)
 end
-puts "Logs recorded."


### PR DESCRIPTION
Aims to resolve #148

- Fixes a bug where instance logs are not recorded for projects with an `end_date`. Now checks that the end date has actually been reached
- Adds more detailed output when running `record_instance_logs.rb`. For each project, indicates if new logs / logs are being overwritten, if any logs are successfully recorded and if there are no logs to record (e.g. project has no nodes)

![Screenshot from 2021-11-04 10-38-13](https://user-images.githubusercontent.com/59840834/140299701-c02a830b-b329-4e9d-9144-157508788113.png)

- Projects that have ended are already excluded when running `record_instance_logs.rb  all`, but if run for that specific project, will report that no logs recorded as the project over

![Screenshot from 2021-11-04 10-48-50](https://user-images.githubusercontent.com/59840834/140301193-620ecaaf-3985-4d08-8b6c-2c703345ce4f.png)
