### PR TITLE
Use active projects when recording latest instance prices and sizes

### DIFF
--- a/get_latest_aws_instance_info.rb
+++ b/get_latest_aws_instance_info.rb
@@ -28,9 +28,9 @@
 require_relative './models/aws_project.rb'
 
 # Need AWS credentials to get instance list, so use a project in database.
-project = AwsProject.first
+project = AwsProject.active.first
 if !project
-  puts "No AWS projects in database to retrieve instances details"
+  puts "No active AWS projects in database to retrieve instances details"
 else
   project.get_aws_instance_info
 end

--- a/get_latest_azure_instance_sizes.rb
+++ b/get_latest_azure_instance_sizes.rb
@@ -28,9 +28,9 @@
 require_relative './models/azure_project.rb'
 
 # Need Azure credentials to get instance list, so use a project in database.
-project = AzureProject.first
+project = AzureProject.active.first
 if !project
-  puts "No Azure projects in database to retrieve price list"
+  puts "No active Azure projects in database to retrieve price list"
 else
   project.get_instance_sizes
 end

--- a/get_latest_azure_prices.rb
+++ b/get_latest_azure_prices.rb
@@ -29,9 +29,9 @@ require_relative './models/azure_project.rb'
 
 # Need Azure credentials to get price list, so use a project in database.
 # Assumes all projects are registered in the UK, using GBP and a 'pay as you go' pricing model.
-project = AzureProject.first
+project = AzureProject.active.first
 if !project
-  puts "No Azure projects in database to retrieve price list"
+  puts "No active Azure projects in database to retrieve price list"
 else
   project.get_prices
 end


### PR DESCRIPTION
Fixes a bug where if the first project for Azure/ AWS is no longer active, trying to record the latest instance sizes or prices fails, as their credentials no longer valid.

Now uses the first _active_ project. If no active projects, that is highlighted in a printed message and no attempt to record new files made.